### PR TITLE
[CIR][COMBINE] Add OffloadContainerOp definition and verification logic

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -50,6 +50,7 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getModuleLevelAsmAttrName() { return "cir.module_asm"; }
     static llvm::StringRef getGlobalCtorsAttrName() { return "cir.global_ctors"; }
     static llvm::StringRef getGlobalDtorsAttrName() { return "cir.global_dtors"; }
+    static llvm::StringRef getOffloadKindAttrName() { return "cir.offload.kind"; }
     static llvm::StringRef getOperandSegmentSizesAttrName() { return "operandSegmentSizes"; }
     static llvm::StringRef getNoCallerSavedRegsAttrName() { return "no_caller_saved_registers"; }
     static llvm::StringRef getNoCallbackAttrName() { return "nocallback"; }

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5595,6 +5595,21 @@ def CIR_DerivedMethodOp : CIR_Op<"derived_method", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// OffloadKind
+//===----------------------------------------------------------------------===//
+
+def CIR_OffloadKind : CIR_I32EnumAttr<"OffloadKind", "offload kind", [
+  I32EnumAttrCase<"Host",   0, "host">,
+  I32EnumAttrCase<"Device", 1, "device">
+]> {
+  let genSpecializedAttr = 0;
+}
+
+def CIR_OffloadKindAttr : CIR_EnumAttr<CIR_OffloadKind, "offload_kind"> {
+  let summary = "Offload kind (host or device)";
+}
+
+//===----------------------------------------------------------------------===//
 // OffloadContainerOp
 //===----------------------------------------------------------------------===//
 
@@ -5605,20 +5620,20 @@ def CIR_OffloadContainerOp : CIR_Op<"offload.container", [
     `cir.offload.container` groups one host CIR module with one or more device
     CIR modules for offload-aware analysis and transformation.
 
-    The operation owns a single symbol table region. Each payload must be a
-    nested builtin `module` operation with a `cir.offload.kind` attribute whose
-    value is either `host` or `device`. The first nested operation is the host
-    module, and all remaining nested operations are device modules.
+    The body holds nested `builtin.module` operations. The first nested
+    module is the host module and must carry
+    `cir.offload.kind = #cir.offload_kind<host>`. All remaining nested
+    modules are device modules and must carry
+    `cir.offload.kind = #cir.offload_kind<device>`. There must be at least
+    one device module.
 
     Example:
 
     ```mlir
-    module {
-      cir.offload.container {
-        builtin.module @host attributes {cir.offload.kind = "host"} {
-        }
-        builtin.module @device_0 attributes {cir.offload.kind = "device"} {
-        }
+    cir.offload.container {
+      builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+      }
+      builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
       }
     }
     ```
@@ -5632,7 +5647,7 @@ def CIR_OffloadContainerOp : CIR_Op<"offload.container", [
   let hasLLVMLowering = false;
 
   let extraClassDeclaration = [{
-    std::optional<mlir::ModuleOp> getHostModule();
+    mlir::ModuleOp getHostModule();
     llvm::iterator_range<mlir::Block::op_iterator<mlir::ModuleOp>>
     getDeviceModules();
   }];

--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5595,6 +5595,50 @@ def CIR_DerivedMethodOp : CIR_Op<"derived_method", [Pure]> {
 }
 
 //===----------------------------------------------------------------------===//
+// OffloadContainerOp
+//===----------------------------------------------------------------------===//
+
+def CIR_OffloadContainerOp : CIR_Op<"offload.container", [
+    NoRegionArguments, NoTerminator, SingleBlock, SymbolTable]> {
+  let summary = "Container for host and device CIR modules";
+  let description = [{
+    `cir.offload.container` groups one host CIR module with one or more device
+    CIR modules for offload-aware analysis and transformation.
+
+    The operation owns a single symbol table region. Each payload must be a
+    nested builtin `module` operation with a `cir.offload.kind` attribute whose
+    value is either `host` or `device`. The first nested operation is the host
+    module, and all remaining nested operations are device modules.
+
+    Example:
+
+    ```mlir
+    module {
+      cir.offload.container {
+        builtin.module @host attributes {cir.offload.kind = "host"} {
+        }
+        builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+        }
+      }
+    }
+    ```
+  }];
+
+  let regions = (region SizedRegion<1>:$body);
+
+  let assemblyFormat = "$body attr-dict";
+
+  let hasVerifier = 1;
+  let hasLLVMLowering = false;
+
+  let extraClassDeclaration = [{
+    std::optional<mlir::ModuleOp> getHostModule();
+    llvm::iterator_range<mlir::Block::op_iterator<mlir::ModuleOp>>
+    getDeviceModules();
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // ComplexCreateOp
 //===----------------------------------------------------------------------===//
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -17,6 +17,7 @@
 #include "clang/CIR/Dialect/IR/CIRTypes.h"
 
 #include "mlir/IR/Attributes.h"
+#include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/DialectImplementation.h"
 #include "mlir/IR/PatternMatch.h"
 #include "mlir/Interfaces/ControlFlowInterfaces.h"
@@ -30,6 +31,8 @@
 #include "llvm/ADT/SmallSet.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Support/LogicalResult.h"
+#include "llvm/Support/raw_ostream.h"
+#include <optional>
 
 using namespace mlir;
 using namespace cir;
@@ -2265,6 +2268,81 @@ LogicalResult cir::VTTAddrPointOp::verify() {
   if (resultType != resTy)
     return emitOpError("result type must be ")
            << resTy << ", but provided result type is " << resultType;
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// OffloadContainerOp
+//===----------------------------------------------------------------------===//
+
+std::optional<mlir::ModuleOp> cir::OffloadContainerOp::getHostModule() {
+  mlir::Block &body = getBody().front();
+  if (body.empty())
+    return std::nullopt;
+
+  // Host module should be the first op in the parent container region
+  auto module = llvm::dyn_cast<mlir::ModuleOp>(body.front());
+  if (!module)
+    return std::nullopt;
+  return module;
+}
+
+llvm::iterator_range<mlir::Block::op_iterator<mlir::ModuleOp>>
+cir::OffloadContainerOp::getDeviceModules() {
+  mlir::Block &body = getBody().front();
+  auto begin = body.op_begin<mlir::ModuleOp>();
+  auto end = body.op_end<mlir::ModuleOp>();
+  // We represent device modules in the range of ops[1..n-1]
+  // where all elements beside ops[0] are device modules.
+  if (begin != end)
+    ++begin;
+  return {begin, end};
+}
+
+LogicalResult cir::OffloadContainerOp::verify() {
+  std::optional<mlir::ModuleOp> hostModuleOpt = getHostModule();
+  if (!hostModuleOpt)
+    return emitOpError() << "expects host module as the first nested op";
+
+  mlir::ModuleOp hostModule = *hostModuleOpt;
+  auto kind = hostModule->getAttrOfType<mlir::StringAttr>(
+      cir::CIRDialect::getOffloadKindAttrName());
+  if (!kind)
+    return hostModule.emitOpError()
+           << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
+           << "' string attribute";
+
+  if (kind.getValue() != "host")
+    return hostModule.emitOpError()
+           << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
+           << "' value 'host'";
+
+  unsigned numDeviceModules = 0;
+  mlir::Block &body = getBody().front();
+  auto it = body.begin();
+  for (++it; it != body.end(); ++it) {
+    auto module = llvm::dyn_cast<mlir::ModuleOp>(*it);
+    if (!module)
+      return emitOpError() << "expects only nested module operations";
+
+    kind = module->getAttrOfType<mlir::StringAttr>(
+        cir::CIRDialect::getOffloadKindAttrName());
+    if (!kind)
+      return module.emitOpError()
+             << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
+             << "' string attribute";
+
+    if (kind.getValue() != "device")
+      return module.emitOpError()
+             << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
+             << "' value 'device'";
+
+    ++numDeviceModules;
+  }
+
+  if (!numDeviceModules)
+    return emitOpError() << "expects at least one device module";
+
   return success();
 }
 

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2276,6 +2276,7 @@ LogicalResult cir::VTTAddrPointOp::verify() {
 //===----------------------------------------------------------------------===//
 
 mlir::ModuleOp cir::OffloadContainerOp::getHostModule() {
+  // Host module should be the first op in the parent's container region
   return mlir::cast<mlir::ModuleOp>(getBody().front().front());
 }
 
@@ -2284,6 +2285,8 @@ cir::OffloadContainerOp::getDeviceModules() {
   mlir::Block &body = getBody().front();
   auto begin = body.op_begin<mlir::ModuleOp>();
   auto end = body.op_end<mlir::ModuleOp>();
+  // We represent device modules in the range of ops[1..n-1]
+  // where all elements beside ops[0] are device modules.
   if (begin != end)
     ++begin;
   return {begin, end};

--- a/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
+++ b/clang/lib/CIR/Dialect/IR/CIRDialect.cpp
@@ -2275,16 +2275,8 @@ LogicalResult cir::VTTAddrPointOp::verify() {
 // OffloadContainerOp
 //===----------------------------------------------------------------------===//
 
-std::optional<mlir::ModuleOp> cir::OffloadContainerOp::getHostModule() {
-  mlir::Block &body = getBody().front();
-  if (body.empty())
-    return std::nullopt;
-
-  // Host module should be the first op in the parent container region
-  auto module = llvm::dyn_cast<mlir::ModuleOp>(body.front());
-  if (!module)
-    return std::nullopt;
-  return module;
+mlir::ModuleOp cir::OffloadContainerOp::getHostModule() {
+  return mlir::cast<mlir::ModuleOp>(getBody().front().front());
 }
 
 llvm::iterator_range<mlir::Block::op_iterator<mlir::ModuleOp>>
@@ -2292,57 +2284,50 @@ cir::OffloadContainerOp::getDeviceModules() {
   mlir::Block &body = getBody().front();
   auto begin = body.op_begin<mlir::ModuleOp>();
   auto end = body.op_end<mlir::ModuleOp>();
-  // We represent device modules in the range of ops[1..n-1]
-  // where all elements beside ops[0] are device modules.
   if (begin != end)
     ++begin;
   return {begin, end};
 }
 
+static LogicalResult checkOffloadKind(mlir::ModuleOp module,
+                                      cir::OffloadKind expected) {
+  auto attr = module->getAttrOfType<cir::OffloadKindAttr>(
+      cir::CIRDialect::getOffloadKindAttrName());
+  if (!attr)
+    return module.emitOpError()
+           << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
+           << "' offload kind attribute";
+  if (attr.getValue() != expected)
+    return module.emitOpError()
+           << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
+           << "' value '" << cir::stringifyOffloadKind(expected) << "'";
+  return success();
+}
+
 LogicalResult cir::OffloadContainerOp::verify() {
-  std::optional<mlir::ModuleOp> hostModuleOpt = getHostModule();
-  if (!hostModuleOpt)
+  mlir::Block &body = getBody().front();
+  if (body.empty())
     return emitOpError() << "expects host module as the first nested op";
 
-  mlir::ModuleOp hostModule = *hostModuleOpt;
-  auto kind = hostModule->getAttrOfType<mlir::StringAttr>(
-      cir::CIRDialect::getOffloadKindAttrName());
-  if (!kind)
-    return hostModule.emitOpError()
-           << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
-           << "' string attribute";
+  auto host = mlir::dyn_cast<mlir::ModuleOp>(body.front());
+  if (!host)
+    return emitOpError() << "expects host module as the first nested op";
+  if (failed(checkOffloadKind(host, cir::OffloadKind::Host)))
+    return failure();
 
-  if (kind.getValue() != "host")
-    return hostModule.emitOpError()
-           << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
-           << "' value 'host'";
-
-  unsigned numDeviceModules = 0;
-  mlir::Block &body = getBody().front();
+  unsigned numDevices = 0;
   auto it = body.begin();
   for (++it; it != body.end(); ++it) {
-    auto module = llvm::dyn_cast<mlir::ModuleOp>(*it);
+    auto module = mlir::dyn_cast<mlir::ModuleOp>(*it);
     if (!module)
-      return emitOpError() << "expects only nested module operations";
-
-    kind = module->getAttrOfType<mlir::StringAttr>(
-        cir::CIRDialect::getOffloadKindAttrName());
-    if (!kind)
-      return module.emitOpError()
-             << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
-             << "' string attribute";
-
-    if (kind.getValue() != "device")
-      return module.emitOpError()
-             << "expects '" << cir::CIRDialect::getOffloadKindAttrName()
-             << "' value 'device'";
-
-    ++numDeviceModules;
+      return emitOpError() << "expects only nested builtin.module ops";
+    if (failed(checkOffloadKind(module, cir::OffloadKind::Device)))
+      return failure();
+    ++numDevices;
   }
 
-  if (!numDeviceModules)
+  if (numDevices == 0)
     return emitOpError() << "expects at least one device module";
-
   return success();
 }
 

--- a/clang/test/CIR/IR/invalid-offload-container.cir
+++ b/clang/test/CIR/IR/invalid-offload-container.cir
@@ -1,0 +1,65 @@
+// RUN: cir-opt %s -verify-diagnostics -split-input-file
+
+module {
+  cir.offload.container {
+    builtin.module @device_0 attributes {cir.offload.kind = "device"} { // expected-error {{expects 'cir.offload.kind' value 'host'}}
+    }
+  }
+}
+
+// -----
+
+module {
+  cir.offload.container {
+    builtin.module @host_0 attributes {cir.offload.kind = "host"} {
+    }
+    builtin.module @host_1 attributes {cir.offload.kind = "host"} { // expected-error {{expects 'cir.offload.kind' value 'device'}}
+    }
+  }
+}
+
+// -----
+
+module {
+  cir.offload.container {
+    builtin.module @host { // expected-error {{expects 'cir.offload.kind' string attribute}}
+    }
+  }
+}
+
+// -----
+
+module {
+  cir.offload.container { // expected-error {{expects only nested module operations}}
+    builtin.module @host attributes {cir.offload.kind = "host"} {
+    }
+    cir.const #cir.int<0> : !cir.int<s, 32>
+  }
+}
+
+// -----
+
+module {
+  cir.offload.container { // expected-error {{expects at least one device module}}
+    builtin.module @host attributes {cir.offload.kind = "host"} {
+    }
+  }
+}
+
+// -----
+
+module {
+  cir.offload.container { // expected-error {{expects host module as the first nested op}}
+  }
+}
+
+// -----
+
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = "host"} {
+    }
+    builtin.module @bad attributes {cir.offload.kind = "other"} { // expected-error {{expects 'cir.offload.kind' value 'device'}}
+    }
+  }
+}

--- a/clang/test/CIR/IR/invalid-offload-container.cir
+++ b/clang/test/CIR/IR/invalid-offload-container.cir
@@ -1,37 +1,41 @@
 // RUN: cir-opt %s -verify-diagnostics -split-input-file
 
+// First nested module has device kind instead of host.
 module {
   cir.offload.container {
-    builtin.module @device_0 attributes {cir.offload.kind = "device"} { // expected-error {{expects 'cir.offload.kind' value 'host'}}
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} { // expected-error {{expects 'cir.offload.kind' value 'host'}}
     }
   }
 }
 
 // -----
 
+// Module after the host has host kind instead of device.
 module {
   cir.offload.container {
-    builtin.module @host_0 attributes {cir.offload.kind = "host"} {
+    builtin.module @host_0 attributes {cir.offload.kind = #cir.offload_kind<host>} {
     }
-    builtin.module @host_1 attributes {cir.offload.kind = "host"} { // expected-error {{expects 'cir.offload.kind' value 'device'}}
+    builtin.module @host_1 attributes {cir.offload.kind = #cir.offload_kind<host>} { // expected-error {{expects 'cir.offload.kind' value 'device'}}
     }
   }
 }
 
 // -----
 
+// First nested module is missing the kind attribute.
 module {
   cir.offload.container {
-    builtin.module @host { // expected-error {{expects 'cir.offload.kind' string attribute}}
+    builtin.module @host { // expected-error {{expects 'cir.offload.kind' offload kind attribute}}
     }
   }
 }
 
 // -----
 
+// Non-module op after the host.
 module {
-  cir.offload.container { // expected-error {{expects only nested module operations}}
-    builtin.module @host attributes {cir.offload.kind = "host"} {
+  cir.offload.container { // expected-error {{expects only nested builtin.module ops}}
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
     }
     cir.const #cir.int<0> : !cir.int<s, 32>
   }
@@ -39,27 +43,18 @@ module {
 
 // -----
 
+// Container has no device modules.
 module {
   cir.offload.container { // expected-error {{expects at least one device module}}
-    builtin.module @host attributes {cir.offload.kind = "host"} {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
     }
   }
 }
 
 // -----
 
+// Container body is empty.
 module {
   cir.offload.container { // expected-error {{expects host module as the first nested op}}
-  }
-}
-
-// -----
-
-module {
-  cir.offload.container {
-    builtin.module @host attributes {cir.offload.kind = "host"} {
-    }
-    builtin.module @bad attributes {cir.offload.kind = "other"} { // expected-error {{expects 'cir.offload.kind' value 'device'}}
-    }
   }
 }

--- a/clang/test/CIR/IR/offload-container.cir
+++ b/clang/test/CIR/IR/offload-container.cir
@@ -1,0 +1,32 @@
+// RUN: cir-opt %s -split-input-file --verify-roundtrip | FileCheck %s
+
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = "host"} {
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+    }
+  }
+}
+
+// CHECK: cir.offload.container {
+// CHECK:   builtin.module @host attributes {cir.offload.kind = "host"} {
+// CHECK:   builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+
+// -----
+
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = "host"} {
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+    }
+    builtin.module @device_1 attributes {cir.offload.kind = "device"} {
+    }
+  }
+}
+
+// CHECK: cir.offload.container {
+// CHECK:   builtin.module @host attributes {cir.offload.kind = "host"} {
+// CHECK:   builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+// CHECK:   builtin.module @device_1 attributes {cir.offload.kind = "device"} {

--- a/clang/test/CIR/IR/offload-container.cir
+++ b/clang/test/CIR/IR/offload-container.cir
@@ -2,31 +2,31 @@
 
 module {
   cir.offload.container {
-    builtin.module @host attributes {cir.offload.kind = "host"} {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
     }
-    builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
     }
   }
 }
 
 // CHECK: cir.offload.container {
-// CHECK:   builtin.module @host attributes {cir.offload.kind = "host"} {
-// CHECK:   builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+// CHECK:   builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+// CHECK:   builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
 
 // -----
 
 module {
   cir.offload.container {
-    builtin.module @host attributes {cir.offload.kind = "host"} {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
     }
-    builtin.module @device_0 attributes {cir.offload.kind = "device"} {
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
     }
-    builtin.module @device_1 attributes {cir.offload.kind = "device"} {
+    builtin.module @device_1 attributes {cir.offload.kind = #cir.offload_kind<device>} {
     }
   }
 }
 
 // CHECK: cir.offload.container {
-// CHECK:   builtin.module @host attributes {cir.offload.kind = "host"} {
-// CHECK:   builtin.module @device_0 attributes {cir.offload.kind = "device"} {
-// CHECK:   builtin.module @device_1 attributes {cir.offload.kind = "device"} {
+// CHECK:   builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+// CHECK:   builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+// CHECK:   builtin.module @device_1 attributes {cir.offload.kind = #cir.offload_kind<device>} {


### PR DESCRIPTION
These are the initial dialect modifications to unblock the tooling functionality coming in later patches.

This is the container structure I'd thought of, largely based on [Dinos' initial prototype](https://github.com/llvm/clangir/pull/2097/changes#diff-b1ef43932d8825bd4d017fe0ce2e40f4cf452f0d88ac0febec793807094b4256). I tried to make the verifiers much more robust, though. To avoid large pointer-chasing chains, the main invariant when compiling for multi-arch remains that the first module in the region is of host kind, while the rest belong to device architectures.

