### PR TITLE
[CIR] Handle frontend/driver side .cir input types

### DIFF
--- a/clang/include/clang/Basic/DiagnosticFrontendKinds.td
+++ b/clang/include/clang/Basic/DiagnosticFrontendKinds.td
@@ -440,6 +440,10 @@ def err_ast_action_on_llvm_ir : Error<
   "cannot apply AST actions to LLVM IR file '%0'">,
   DefaultFatal;
 
+def err_ast_action_on_cir : Error<
+  "cannot apply AST actions to CIR file '%0'">,
+  DefaultFatal;
+
 def err_invalid_llvm_ir : Error<"invalid LLVM IR input: %0">;
 
 def err_os_unsupport_riscv_fmv : Error<

--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -62,7 +62,7 @@ protected:
 public:
   ~CIRGenAction() override;
 
-  bool hasIRSupport() const override;
+  bool hasCIRSupport() const override;
 
   OutputType Action;
 };

--- a/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
+++ b/clang/include/clang/CIR/FrontendAction/CIRGenAction.h
@@ -57,8 +57,12 @@ protected:
   CreateASTConsumer(clang::CompilerInstance &CI,
                     llvm::StringRef InFile) override;
 
+  void ExecuteAction() override;
+
 public:
   ~CIRGenAction() override;
+
+  bool hasIRSupport() const override;
 
   OutputType Action;
 };

--- a/clang/include/clang/Frontend/FrontendAction.h
+++ b/clang/include/clang/Frontend/FrontendAction.h
@@ -208,6 +208,9 @@ public:
   /// Does this action support use with IR files?
   virtual bool hasIRSupport() const { return false; }
 
+  /// Does this action support use with CIR files?
+  virtual bool hasCIRSupport() const { return false; }
+
   /// Does this action support use with code completion?
   virtual bool hasCodeCompletionSupport() const { return false; }
 
@@ -338,6 +341,7 @@ public:
   bool hasPCHSupport() const override;
   bool hasASTFileSupport() const override;
   bool hasIRSupport() const override;
+  bool hasCIRSupport() const override;
   bool hasCodeCompletionSupport() const override;
 };
 

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -7,11 +7,22 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/CIR/FrontendAction/CIRGenAction.h"
+#include "mlir/Dialect/DLTI/DLTI.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/IR/BuiltinDialect.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/DialectRegistry.h"
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/OwningOpRef.h"
+#include "mlir/IR/Verifier.h"
+#include "mlir/Parser/Parser.h"
 #include "clang/Basic/DiagnosticFrontend.h"
 #include "clang/CIR/CIRGenerator.h"
 #include "clang/CIR/CIRToCIRPasses.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
 #include "clang/CIR/LowerToLLVM.h"
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/ModuleLinker.h"
@@ -26,6 +37,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/Linker/Linker.h"
 #include "llvm/Support/Path.h"
+#include "llvm/Support/SourceMgr.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO/Internalize.h"
 
@@ -61,6 +73,86 @@ lowerFromCIRToLLVMIR(mlir::ModuleOp MLIRModule, llvm::LLVMContext &LLVMCtx,
                      llvm::vfs::FileSystem *fs = nullptr) {
   return direct::lowerDirectlyFromCIRToLLVMIR(MLIRModule, LLVMCtx,
                                               mlirSaveTempsOutFile, fs);
+}
+
+static void registerDialects(mlir::DialectRegistry &registry) {
+  registry.insert<mlir::BuiltinDialect, cir::CIRDialect,
+                  mlir::memref::MemRefDialect, mlir::LLVM::LLVMDialect,
+                  mlir::DLTIDialect, mlir::omp::OpenMPDialect>();
+  cir::omp::registerOpenMPExtensions(registry);
+}
+
+static void prepareCIRInputContext(mlir::MLIRContext &context) {
+  mlir::DialectRegistry registry;
+  registerDialects(registry);
+  context.appendDialectRegistry(registry);
+  context.loadDialect<cir::CIRDialect, mlir::memref::MemRefDialect,
+                      mlir::LLVM::LLVMDialect, mlir::DLTIDialect,
+                      mlir::omp::OpenMPDialect>();
+}
+
+static void reportError(CompilerInstance &CI, llvm::Twine message) {
+  unsigned DiagID =
+      CI.getDiagnostics().getCustomDiagID(DiagnosticsEngine::Error, "%0");
+  CI.getDiagnostics().Report(DiagID) << message.str();
+}
+
+static mlir::OwningOpRef<mlir::ModuleOp>
+parseCIRInput(CompilerInstance &CI, mlir::MLIRContext &context,
+              llvm::MemoryBufferRef input) {
+  auto sourceMgr = std::make_shared<llvm::SourceMgr>();
+  sourceMgr->AddNewSourceBuffer(
+      llvm::MemoryBuffer::getMemBufferCopy(input.getBuffer(),
+                                           input.getBufferIdentifier()),
+      llvm::SMLoc());
+
+  mlir::SourceMgrDiagnosticHandler sourceMgrHandler(*sourceMgr, &context);
+  mlir::ParserConfig parserConfig(&context, /*verifyAfterParse=*/false);
+  auto module = mlir::parseSourceFile<mlir::ModuleOp>(sourceMgr, parserConfig);
+  if (!module) {
+    reportError(CI, "failed to parse CIR input");
+    return {};
+  }
+  if (mlir::failed(mlir::verify(*module))) {
+    reportError(CI, "failed to verify CIR input");
+    return {};
+  }
+  return module;
+}
+
+static bool linkInModules(CompilerInstance &CI, CodeGenOptions &CGO,
+                          llvm::Module &M,
+                          SmallVectorImpl<::clang::LinkModule> &LinkModules) {
+  for (auto &LM : LinkModules) {
+    assert(LM.Module && "LinkModule does not actually have a module");
+
+    if (LM.PropagateAttrs)
+      for (llvm::Function &F : *LM.Module) {
+        if (F.isIntrinsic())
+          continue;
+        clang::CodeGen::mergeDefaultFunctionDefinitionAttributes(
+            F, CGO, CI.getLangOpts(), CI.getTargetOpts(), LM.Internalize);
+      }
+
+    bool Err;
+    if (LM.Internalize) {
+      Err = llvm::Linker::linkModules(
+          M, std::move(LM.Module), LM.LinkFlags,
+          [](llvm::Module &M, const llvm::StringSet<> &GVS) {
+            llvm::internalizeModule(M, [&GVS](const llvm::GlobalValue &GV) {
+              return !GV.hasName() || (GVS.count(GV.getName()) == 0);
+            });
+          });
+    } else {
+      Err = llvm::Linker::linkModules(M, std::move(LM.Module), LM.LinkFlags);
+    }
+
+    if (Err)
+      return true;
+  }
+
+  LinkModules.clear();
+  return false;
 }
 
 class CIRGenConsumer : public clang::ASTConsumer {
@@ -178,7 +270,7 @@ public:
           lowerFromCIRToLLVMIR(MlirModule, LLVMCtx, mlirSaveTempsOutFile,
                                &CI.getVirtualFileSystem());
 
-      if (linkInModules(*LLVMModule))
+      if (linkInModules(CI, CGO, *LLVMModule, LinkModules))
         return;
 
       BackendAction BEAction = getBackendActionFromOutputType(Action);
@@ -188,41 +280,6 @@ public:
       break;
     }
     }
-  }
-
-  // TODO: share with BackendConsumer::LinkInModules once OG's CurLinkModule
-  // diagnostic-handler indirection is abstracted behind a callback for CIR.
-  bool linkInModules(llvm::Module &M) {
-    for (auto &LM : LinkModules) {
-      assert(LM.Module && "LinkModule does not actually have a module");
-
-      if (LM.PropagateAttrs)
-        for (llvm::Function &F : *LM.Module) {
-          if (F.isIntrinsic())
-            continue;
-          clang::CodeGen::mergeDefaultFunctionDefinitionAttributes(
-              F, CGO, CI.getLangOpts(), CI.getTargetOpts(), LM.Internalize);
-        }
-
-      bool Err;
-      if (LM.Internalize) {
-        Err = llvm::Linker::linkModules(
-            M, std::move(LM.Module), LM.LinkFlags,
-            [](llvm::Module &M, const llvm::StringSet<> &GVS) {
-              llvm::internalizeModule(M, [&GVS](const llvm::GlobalValue &GV) {
-                return !GV.hasName() || (GVS.count(GV.getName()) == 0);
-              });
-            });
-      } else {
-        Err = llvm::Linker::linkModules(M, std::move(LM.Module), LM.LinkFlags);
-      }
-
-      if (Err)
-        return true;
-    }
-
-    LinkModules.clear();
-    return false;
   }
 
   void HandleTagDeclDefinition(TagDecl *D) override {
@@ -274,6 +331,62 @@ getOutputStream(CompilerInstance &CI, StringRef InFile,
     return CI.createDefaultOutputFile(true, InFile, "o");
   }
   llvm_unreachable("Invalid CIRGenAction::OutputType");
+}
+
+bool CIRGenAction::hasIRSupport() const { return true; }
+
+void CIRGenAction::ExecuteAction() {
+  if (getCurrentFileKind().getLanguage() != Language::CIR) {
+    ASTFrontendAction::ExecuteAction();
+    return;
+  }
+
+  CompilerInstance &CI = getCompilerInstance();
+  std::unique_ptr<llvm::raw_pwrite_stream> OS = CI.takeOutputStream();
+  if (!OS)
+    OS = getOutputStream(CI, getCurrentFileOrBufferName(), Action);
+  if (!OS)
+    return;
+
+  SourceManager &SM = CI.getSourceManager();
+  std::optional<llvm::MemoryBufferRef> MainFile =
+      SM.getBufferOrNone(SM.getMainFileID());
+  if (!MainFile)
+    return;
+
+  prepareCIRInputContext(*MLIRCtx);
+  MLIRMod = parseCIRInput(CI, *MLIRCtx, *MainFile);
+  if (!MLIRMod)
+    return;
+
+  if (Action == OutputType::EmitCIR) {
+    mlir::OpPrintingFlags Flags;
+    Flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
+    MLIRMod->print(*OS, Flags);
+    return;
+  }
+
+  std::string mlirSaveTempsOutFile;
+  if (!CI.getCodeGenOpts().SaveTempsFilePrefix.empty()) {
+    SmallString<128> stem(CI.getCodeGenOpts().SaveTempsFilePrefix);
+    llvm::sys::path::replace_extension(stem, "mlir");
+    mlirSaveTempsOutFile = std::string(stem);
+  }
+
+  std::unique_ptr<llvm::Module> LLVMModule =
+      lowerFromCIRToLLVMIR(*MLIRMod, *Ctx, mlirSaveTempsOutFile,
+                           &CI.getVirtualFileSystem());
+  if (!LLVMModule)
+    return;
+
+  if (linkInModules(CI, CI.getCodeGenOpts(), *LLVMModule, LinkModules))
+    return;
+
+  BackendAction BEAction = getBackendActionFromOutputType(Action);
+  emitBackendOutput(CI, CI.getCodeGenOpts(),
+                    CI.getTarget().getDataLayoutString(), LLVMModule.get(),
+                    BEAction, CI.getFileManager().getVirtualFileSystemPtr(),
+                    std::move(OS));
 }
 
 std::unique_ptr<ASTConsumer>

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -333,7 +333,7 @@ getOutputStream(CompilerInstance &CI, StringRef InFile,
   llvm_unreachable("Invalid CIRGenAction::OutputType");
 }
 
-bool CIRGenAction::hasIRSupport() const { return true; }
+bool CIRGenAction::hasCIRSupport() const { return true; }
 
 void CIRGenAction::ExecuteAction() {
   if (getCurrentFileKind().getLanguage() != Language::CIR) {

--- a/clang/lib/Driver/Types.cpp
+++ b/clang/lib/Driver/Types.cpp
@@ -151,6 +151,7 @@ bool types::isAcceptedByClang(ID Id) {
   case TY_CXXModule: case TY_PP_CXXModule:
   case TY_AST: case TY_ModuleFile: case TY_PCH:
   case TY_LLVM_IR: case TY_LLVM_BC:
+  case TY_CIR:
   case TY_API_INFO:
     return true;
   }

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3291,6 +3291,11 @@ static bool ParseFrontendArgs(FrontendOptions &Opts, ArgList &Args,
 
   Opts.DashX = DashX;
 
+  if (llvm::any_of(Opts.Inputs, [](const FrontendInputFile &Input) {
+        return Input.getKind().getLanguage() == Language::CIR;
+      }))
+    Opts.UseClangIRPipeline = true;
+
   // CIR is a source-level frontend pipeline. When the input is already LLVM IR
   // (e.g. during the backend phase of OpenMP offloading), the standard LLVM
   // backend should be used instead.

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1000,8 +1000,9 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
   if (CI.getFrontendOpts().ModulesEmbedAllFiles)
     CI.getSourceManager().setAllFilesAreTransient(true);
 
-  // IR files bypass the rest of initialization.
-  if (Input.getKind().getLanguage() == Language::LLVM_IR) {
+  // Serialized IR files bypass the rest of source frontend initialization.
+  if (Input.getKind().getLanguage() == Language::LLVM_IR ||
+      Input.getKind().getLanguage() == Language::CIR) {
     if (!hasIRSupport()) {
       CI.getDiagnostics().Report(diag::err_ast_action_on_llvm_ir)
           << Input.getFile();

--- a/clang/lib/Frontend/FrontendAction.cpp
+++ b/clang/lib/Frontend/FrontendAction.cpp
@@ -1001,10 +1001,15 @@ bool FrontendAction::BeginSourceFile(CompilerInstance &CI,
     CI.getSourceManager().setAllFilesAreTransient(true);
 
   // Serialized IR files bypass the rest of source frontend initialization.
-  if (Input.getKind().getLanguage() == Language::LLVM_IR ||
-      Input.getKind().getLanguage() == Language::CIR) {
-    if (!hasIRSupport()) {
+  Language InputLang = Input.getKind().getLanguage();
+  if (InputLang == Language::LLVM_IR || InputLang == Language::CIR) {
+    if (InputLang == Language::LLVM_IR && !hasIRSupport()) {
       CI.getDiagnostics().Report(diag::err_ast_action_on_llvm_ir)
+          << Input.getFile();
+      return false;
+    }
+    if (InputLang == Language::CIR && !hasCIRSupport()) {
+      CI.getDiagnostics().Report(diag::err_ast_action_on_cir)
           << Input.getFile();
       return false;
     }
@@ -1516,6 +1521,9 @@ bool WrapperFrontendAction::hasASTFileSupport() const {
 }
 bool WrapperFrontendAction::hasIRSupport() const {
   return WrappedAction->hasIRSupport();
+}
+bool WrapperFrontendAction::hasCIRSupport() const {
+  return WrappedAction->hasCIRSupport();
 }
 bool WrapperFrontendAction::hasCodeCompletionSupport() const {
   return WrappedAction->hasCodeCompletionSupport();

--- a/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
+++ b/clang/lib/FrontendTool/ExecuteCompilerInvocation.cpp
@@ -58,6 +58,13 @@ CreateFrontendBaseAction(CompilerInstance &CI) {
   if (!UseCIR && EmitsCIR)
     llvm::report_fatal_error("-emit-cir and only valid when using -fclangir");
 
+#if !CLANG_ENABLE_CIR
+  if (UseCIR) {
+    CI.getDiagnostics().Report(diag::err_fe_cir_not_built);
+    return nullptr;
+  }
+#endif
+
   switch (CI.getFrontendOpts().ProgramAction) {
   case ASTDeclList:            return std::make_unique<ASTDeclListAction>();
   case ASTDump:                return std::make_unique<ASTDumpAction>();

--- a/clang/test/CIR/CodeGen/cir-input.c
+++ b/clang/test/CIR/CodeGen/cir-input.c
@@ -1,0 +1,31 @@
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -fclangir -emit-cir %s -o %t.cir
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.cir -emit-llvm -o - | FileCheck %s --check-prefix=LLVM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.cir -emit-llvm-bc -o %t.bc
+// RUN: llvm-dis %t.bc -o - | FileCheck %s --check-prefix=BC
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.cir -S -o - | FileCheck %s --check-prefix=ASM
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.cir -emit-obj -o %t.o
+// RUN: llvm-objdump -t %t.o | FileCheck %s --check-prefix=OBJ
+// RUN: echo "not cir" > %t.invalid.cir
+// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.invalid.cir -emit-llvm -o - 2>&1 | FileCheck %s --check-prefix=INVALID
+
+// REQUIRES: x86-registered-target
+
+int x = 1;
+
+int f(void) {
+  return x;
+}
+
+// LLVM: @x = {{(dso_local )?}}global i32 1
+// LLVM: define{{.*}} i32 @f()
+
+// BC: @x = {{(dso_local )?}}global i32 1
+// BC: define{{.*}} i32 @f()
+
+// ASM: x:
+// ASM: .long   1
+
+// OBJ: .data
+// OBJ-SAME: x
+
+// INVALID: failed to parse CIR input

--- a/clang/test/CIR/CodeGen/cir-input.c
+++ b/clang/test/CIR/CodeGen/cir-input.c
@@ -5,6 +5,7 @@
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.cir -S -o - | FileCheck %s --check-prefix=ASM
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.cir -emit-obj -o %t.o
 // RUN: llvm-objdump -t %t.o | FileCheck %s --check-prefix=OBJ
+// RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.cir -fsyntax-only 2>&1 | FileCheck %s --check-prefix=NO-AST
 // RUN: echo "not cir" > %t.invalid.cir
 // RUN: not %clang_cc1 -triple x86_64-unknown-linux-gnu -x cir %t.invalid.cir -emit-llvm -o - 2>&1 | FileCheck %s --check-prefix=INVALID
 
@@ -27,5 +28,7 @@ int f(void) {
 
 // OBJ: .data
 // OBJ-SAME: x
+
+// NO-AST: cannot apply AST actions to CIR file
 
 // INVALID: failed to parse CIR input

--- a/clang/test/Frontend/cir-not-built.c
+++ b/clang/test/Frontend/cir-not-built.c
@@ -5,6 +5,7 @@
 // UNSUPPORTED: cir-support
 
 // RUN: not %clang_cc1 -emit-cir %s 2>&1 | FileCheck %s
+// RUN: not %clang_cc1 -x cir %s -emit-llvm 2>&1 | FileCheck %s
 // CHECK: error: clang IR support not available, rebuild clang with -DCLANG_ENABLE_CIR=ON
 
 int main(void) {


### PR DESCRIPTION
Basically this allows us to feed `.cir` files into cc1 so that they end up emitting the proper backend action. This is in preparation of the multiple TU's that will be yielded by the merge tool via split. As of now This is limited to deserialization of cir files, which are subsequently lowered to LLVM. Besides that, no passes or other transformations happen on the module.

For context, this isn't the intended behavior for .cir inputs in the future/upstream. We plan to assume the boundary exposed at this point is a TU where target-agnostic passes have run, and we'd ideally run all abi/target-specific transformations.