### PR TITLE
[CIR][NFC] Initial CIRMergeJobAction, CIRMergeJobAction definition and mapping to CIROffloadMerge

### DIFF
--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -71,6 +71,8 @@ public:
     VerifyPCHJobClass,
     OffloadBundlingJobClass,
     OffloadUnbundlingJobClass,
+    CIRMergeJobClass,
+    CIRSplitJobClass,
     OffloadPackagerJobClass,
     LinkerWrapperJobClass,
     StaticLibJobClass,
@@ -633,6 +635,80 @@ public:
 
   static bool classof(const Action *A) {
     return A->getKind() == OffloadUnbundlingJobClass;
+  }
+};
+
+class CIRMergeJobAction final : public JobAction {
+  void anchor() override;
+
+public:
+  struct DependentActionInfo final {
+    const ToolChain *DependentToolChain = nullptr;
+    StringRef DependentBoundArch;
+    const OffloadKind DependentOffloadKind = OFK_None;
+
+    DependentActionInfo(const ToolChain *DependentToolChain,
+                        StringRef DependentBoundArch,
+                        const OffloadKind DependentOffloadKind)
+        : DependentToolChain(DependentToolChain),
+          DependentBoundArch(DependentBoundArch),
+          DependentOffloadKind(DependentOffloadKind) {}
+  };
+
+private:
+  SmallVector<DependentActionInfo, 6> DependentActionInfoArray;
+
+public:
+  CIRMergeJobAction(ActionList &Inputs);
+
+  void registerDependentActionInfo(const ToolChain *TC, StringRef BoundArch,
+                                   OffloadKind Kind) {
+    DependentActionInfoArray.push_back({TC, BoundArch, Kind});
+  }
+
+  ArrayRef<DependentActionInfo> getDependentActionsInfo() const {
+    return DependentActionInfoArray;
+  }
+
+  static bool classof(const Action *A) {
+    return A->getKind() == CIRMergeJobClass;
+  }
+};
+
+class CIRSplitJobAction final : public JobAction {
+  void anchor() override;
+
+public:
+  struct DependentActionInfo final {
+    const ToolChain *DependentToolChain = nullptr;
+    StringRef DependentBoundArch;
+    const OffloadKind DependentOffloadKind = OFK_None;
+
+    DependentActionInfo(const ToolChain *DependentToolChain,
+                        StringRef DependentBoundArch,
+                        const OffloadKind DependentOffloadKind)
+        : DependentToolChain(DependentToolChain),
+          DependentBoundArch(DependentBoundArch),
+          DependentOffloadKind(DependentOffloadKind) {}
+  };
+
+private:
+  SmallVector<DependentActionInfo, 6> DependentActionInfoArray;
+
+public:
+  CIRSplitJobAction(Action *Input);
+
+  void registerDependentActionInfo(const ToolChain *TC, StringRef BoundArch,
+                                   OffloadKind Kind) {
+    DependentActionInfoArray.push_back({TC, BoundArch, Kind});
+  }
+
+  ArrayRef<DependentActionInfo> getDependentActionsInfo() const {
+    return DependentActionInfoArray;
+  }
+
+  static bool classof(const Action *A) {
+    return A->getKind() == CIRSplitJobClass;
   }
 };
 

--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -589,12 +589,12 @@ public:
   }
 };
 
-class OffloadUnbundlingJobAction final : public JobAction {
-  void anchor() override;
-
+/// Base for job actions that fan out to several dependent actions, each with
+/// its own tool chain, bound architecture, and offload kind (e.g. offload
+/// unbundling, CIR merge/split).
+class JobActionWithDependentInfo : public JobAction {
 public:
-  /// Type that provides information about the actions that depend on this
-  /// unbundling action.
+  /// Type that provides information about the actions that depend on this one.
   struct DependentActionInfo final {
     /// The tool chain of the dependent action.
     const ToolChain *DependentToolChain = nullptr;
@@ -613,15 +613,6 @@ public:
           DependentOffloadKind(DependentOffloadKind) {}
   };
 
-private:
-  /// Container that keeps information about each dependence of this unbundling
-  /// action.
-  SmallVector<DependentActionInfo, 6> DependentActionInfoArray;
-
-public:
-  // Offloading unbundling doesn't change the type of output.
-  OffloadUnbundlingJobAction(Action *Input);
-
   /// Register information about a dependent action.
   void registerDependentActionInfo(const ToolChain *TC, StringRef BoundArch,
                                    OffloadKind Kind) {
@@ -633,79 +624,46 @@ public:
     return DependentActionInfoArray;
   }
 
+protected:
+  JobActionWithDependentInfo(ActionClass Kind, Action *Input, types::ID Type)
+      : JobAction(Kind, Input, Type) {}
+  JobActionWithDependentInfo(ActionClass Kind, ActionList &Inputs,
+                             types::ID Type)
+      : JobAction(Kind, Inputs, Type) {}
+
+private:
+  /// Container that keeps information about each dependence of this action.
+  SmallVector<DependentActionInfo, 6> DependentActionInfoArray;
+};
+
+class OffloadUnbundlingJobAction final : public JobActionWithDependentInfo {
+  void anchor() override;
+
+public:
+  // Offloading unbundling doesn't change the type of output.
+  OffloadUnbundlingJobAction(Action *Input);
+
   static bool classof(const Action *A) {
     return A->getKind() == OffloadUnbundlingJobClass;
   }
 };
 
-class CIRMergeJobAction final : public JobAction {
+class CIRMergeJobAction final : public JobActionWithDependentInfo {
   void anchor() override;
 
 public:
-  struct DependentActionInfo final {
-    const ToolChain *DependentToolChain = nullptr;
-    StringRef DependentBoundArch;
-    const OffloadKind DependentOffloadKind = OFK_None;
-
-    DependentActionInfo(const ToolChain *DependentToolChain,
-                        StringRef DependentBoundArch,
-                        const OffloadKind DependentOffloadKind)
-        : DependentToolChain(DependentToolChain),
-          DependentBoundArch(DependentBoundArch),
-          DependentOffloadKind(DependentOffloadKind) {}
-  };
-
-private:
-  SmallVector<DependentActionInfo, 6> DependentActionInfoArray;
-
-public:
   CIRMergeJobAction(ActionList &Inputs);
-
-  void registerDependentActionInfo(const ToolChain *TC, StringRef BoundArch,
-                                   OffloadKind Kind) {
-    DependentActionInfoArray.push_back({TC, BoundArch, Kind});
-  }
-
-  ArrayRef<DependentActionInfo> getDependentActionsInfo() const {
-    return DependentActionInfoArray;
-  }
 
   static bool classof(const Action *A) {
     return A->getKind() == CIRMergeJobClass;
   }
 };
 
-class CIRSplitJobAction final : public JobAction {
+class CIRSplitJobAction final : public JobActionWithDependentInfo {
   void anchor() override;
 
 public:
-  struct DependentActionInfo final {
-    const ToolChain *DependentToolChain = nullptr;
-    StringRef DependentBoundArch;
-    const OffloadKind DependentOffloadKind = OFK_None;
-
-    DependentActionInfo(const ToolChain *DependentToolChain,
-                        StringRef DependentBoundArch,
-                        const OffloadKind DependentOffloadKind)
-        : DependentToolChain(DependentToolChain),
-          DependentBoundArch(DependentBoundArch),
-          DependentOffloadKind(DependentOffloadKind) {}
-  };
-
-private:
-  SmallVector<DependentActionInfo, 6> DependentActionInfoArray;
-
-public:
   CIRSplitJobAction(Action *Input);
-
-  void registerDependentActionInfo(const ToolChain *TC, StringRef BoundArch,
-                                   OffloadKind Kind) {
-    DependentActionInfoArray.push_back({TC, BoundArch, Kind});
-  }
-
-  ArrayRef<DependentActionInfo> getDependentActionsInfo() const {
-    return DependentActionInfoArray;
-  }
 
   static bool classof(const Action *A) {
     return A->getKind() == CIRSplitJobClass;

--- a/clang/include/clang/Driver/ToolChain.h
+++ b/clang/include/clang/Driver/ToolChain.h
@@ -172,6 +172,7 @@ private:
   mutable std::unique_ptr<Tool> StaticLibTool;
   mutable std::unique_ptr<Tool> IfsMerge;
   mutable std::unique_ptr<Tool> OffloadBundler;
+  mutable std::unique_ptr<Tool> CIROffloadMerge;
   mutable std::unique_ptr<Tool> OffloadPackager;
   mutable std::unique_ptr<Tool> LinkerWrapper;
 
@@ -183,6 +184,7 @@ private:
   Tool *getIfsMerge() const;
   Tool *getClangAs() const;
   Tool *getOffloadBundler() const;
+  Tool *getCIROffloadMerge() const;
   Tool *getOffloadPackager() const;
   Tool *getLinkerWrapper() const;
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -42,6 +42,10 @@ const char *Action::getClassName(ActionClass AC) {
     return "clang-offload-bundler";
   case OffloadUnbundlingJobClass:
     return "clang-offload-unbundler";
+  case CIRMergeJobClass:
+    return "cir-offload-merge";
+  case CIRSplitJobClass:
+    return "cir-offload-split";
   case OffloadPackagerJobClass:
     return "llvm-offload-binary";
   case LinkerWrapperJobClass:
@@ -441,6 +445,16 @@ void OffloadUnbundlingJobAction::anchor() {}
 
 OffloadUnbundlingJobAction::OffloadUnbundlingJobAction(Action *Input)
     : JobAction(OffloadUnbundlingJobClass, Input, Input->getType()) {}
+
+void CIRMergeJobAction::anchor() {}
+
+CIRMergeJobAction::CIRMergeJobAction(ActionList &Inputs)
+    : JobAction(CIRMergeJobClass, Inputs, types::TY_CIR) {}
+
+void CIRSplitJobAction::anchor() {}
+
+CIRSplitJobAction::CIRSplitJobAction(Action *Input)
+    : JobAction(CIRSplitJobClass, Input, types::TY_CIR) {}
 
 void OffloadPackagerJobAction::anchor() {}
 

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -444,17 +444,21 @@ OffloadBundlingJobAction::OffloadBundlingJobAction(ActionList &Inputs)
 void OffloadUnbundlingJobAction::anchor() {}
 
 OffloadUnbundlingJobAction::OffloadUnbundlingJobAction(Action *Input)
-    : JobAction(OffloadUnbundlingJobClass, Input, Input->getType()) {}
+    : JobActionWithDependentInfo(OffloadUnbundlingJobClass, Input,
+                                 Input->getType()) {}
 
 void CIRMergeJobAction::anchor() {}
 
 CIRMergeJobAction::CIRMergeJobAction(ActionList &Inputs)
-    : JobAction(CIRMergeJobClass, Inputs, types::TY_CIR) {}
+    : JobActionWithDependentInfo(CIRMergeJobClass, Inputs, types::TY_CIR) {}
 
 void CIRSplitJobAction::anchor() {}
 
 CIRSplitJobAction::CIRSplitJobAction(Action *Input)
-    : JobAction(CIRSplitJobClass, Input, types::TY_CIR) {}
+    : JobActionWithDependentInfo(CIRSplitJobClass, Input, Input->getType()) {
+  assert(Input->getType() == types::TY_CIR &&
+         "CIR split expects a CIR container input");
+}
 
 void OffloadPackagerJobAction::anchor() {}
 

--- a/clang/lib/Driver/ToolChain.cpp
+++ b/clang/lib/Driver/ToolChain.cpp
@@ -742,6 +742,12 @@ Tool *ToolChain::getOffloadBundler() const {
   return OffloadBundler.get();
 }
 
+Tool *ToolChain::getCIROffloadMerge() const {
+  if (!CIROffloadMerge)
+    CIROffloadMerge.reset(new tools::CIROffloadMerge(*this));
+  return CIROffloadMerge.get();
+}
+
 Tool *ToolChain::getOffloadPackager() const {
   if (!OffloadPackager)
     OffloadPackager.reset(new tools::OffloadPackager(*this));
@@ -791,6 +797,10 @@ Tool *ToolChain::getTool(Action::ActionClass AC) const {
   case Action::OffloadBundlingJobClass:
   case Action::OffloadUnbundlingJobClass:
     return getOffloadBundler();
+
+  case Action::CIRMergeJobClass:
+  case Action::CIRSplitJobClass:
+    return getCIROffloadMerge();
 
   case Action::OffloadPackagerJobClass:
     return getOffloadPackager();

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9443,31 +9443,26 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       CmdArgs, ArrayRef<InputInfo>(), Outputs));
 }
 
-static void appendCIROffloadTarget(SmallString<128> &Targets,
-                                   Action::OffloadKind Kind,
-                                   const ToolChain *TC, StringRef BoundArch) {
-  Targets += Action::GetOffloadKindName(Kind);
-  Targets += '-';
-  Targets += TC->getTriple().normalize(llvm::Triple::CanonicalForm::FOUR_IDENT);
-  if ((Kind == Action::OFK_Cuda || Kind == Action::OFK_HIP ||
-       Kind == Action::OFK_OpenMP) &&
-      !BoundArch.empty()) {
-    Targets += '-';
-    Targets += BoundArch;
-  }
-}
-
 static void addCIROffloadTargetsArg(
     const llvm::opt::ArgList &TCArgs, ArgStringList &CmdArgs,
     ArrayRef<JobActionWithDependentInfo::DependentActionInfo> DepInfo) {
   SmallString<128> Targets;
   Targets += "--targets=";
   for (unsigned I = 0; I < DepInfo.size(); ++I) {
+    const auto &Dep = DepInfo[I];
     if (I)
       Targets += ',';
-    appendCIROffloadTarget(Targets, DepInfo[I].DependentOffloadKind,
-                           DepInfo[I].DependentToolChain,
-                           DepInfo[I].DependentBoundArch);
+    Targets += Action::GetOffloadKindName(Dep.DependentOffloadKind);
+    Targets += '-';
+    Targets += Dep.DependentToolChain->getTriple().normalize(
+        llvm::Triple::CanonicalForm::FOUR_IDENT);
+    if ((Dep.DependentOffloadKind == Action::OFK_Cuda ||
+         Dep.DependentOffloadKind == Action::OFK_HIP ||
+         Dep.DependentOffloadKind == Action::OFK_OpenMP) &&
+        !Dep.DependentBoundArch.empty()) {
+      Targets += '-';
+      Targets += Dep.DependentBoundArch;
+    }
   }
   CmdArgs.push_back(TCArgs.MakeArgString(Targets));
 }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9443,6 +9443,100 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       CmdArgs, ArrayRef<InputInfo>(), Outputs));
 }
 
+static void appendCIROffloadTarget(SmallString<128> &Targets,
+                                   Action::OffloadKind Kind,
+                                   const ToolChain *TC, StringRef BoundArch) {
+  Targets += Action::GetOffloadKindName(Kind);
+  Targets += '-';
+  Targets += TC->getTriple().normalize(llvm::Triple::CanonicalForm::FOUR_IDENT);
+  if ((Kind == Action::OFK_Cuda || Kind == Action::OFK_HIP ||
+       Kind == Action::OFK_OpenMP) &&
+      !BoundArch.empty()) {
+    Targets += '-';
+    Targets += BoundArch;
+  }
+}
+
+void CIROffloadMerge::ConstructJob(Compilation &C, const JobAction &JA,
+                                   const InputInfo &Output,
+                                   const InputInfoList &Inputs,
+                                   const llvm::opt::ArgList &TCArgs,
+                                   const char *LinkingOutput) const {
+  auto &MA = cast<CIRMergeJobAction>(JA);
+  auto DepInfo = MA.getDependentActionsInfo();
+  assert(Inputs.size() == DepInfo.size() &&
+         "Expected one target for each CIR merge input");
+
+  ArgStringList CmdArgs;
+  CmdArgs.push_back("--combine");
+
+  SmallString<128> Targets;
+  Targets += "--targets=";
+  for (unsigned I = 0; I < DepInfo.size(); ++I) {
+    if (I)
+      Targets += ',';
+    appendCIROffloadTarget(Targets, DepInfo[I].DependentOffloadKind,
+                           DepInfo[I].DependentToolChain,
+                           DepInfo[I].DependentBoundArch);
+  }
+  CmdArgs.push_back(TCArgs.MakeArgString(Targets));
+
+  CmdArgs.push_back(
+      TCArgs.MakeArgString(Twine("--output=") + Output.getFilename()));
+
+  for (unsigned I = 0; I < Inputs.size(); ++I) {
+    SmallString<128> Input;
+    Input += "--input=";
+    Input += DepInfo[I].DependentToolChain->getInputFilename(Inputs[I]);
+    CmdArgs.push_back(TCArgs.MakeArgString(Input));
+  }
+
+  C.addCommand(std::make_unique<Command>(
+      JA, *this, ResponseFileSupport::None(),
+      TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),
+      CmdArgs, ArrayRef<InputInfo>(), Output));
+}
+
+void CIROffloadMerge::ConstructJobMultipleOutputs(
+    Compilation &C, const JobAction &JA, const InputInfoList &Outputs,
+    const InputInfoList &Inputs, const llvm::opt::ArgList &TCArgs,
+    const char *LinkingOutput) const {
+  auto &SA = cast<CIRSplitJobAction>(JA);
+  auto DepInfo = SA.getDependentActionsInfo();
+  assert(Inputs.size() == 1 && "Expected one CIR split input");
+  assert(Outputs.size() == DepInfo.size() &&
+         "Expected one CIR split output for each target");
+
+  ArgStringList CmdArgs;
+  CmdArgs.push_back("--split");
+
+  SmallString<128> Targets;
+  Targets += "--targets=";
+  for (unsigned I = 0; I < DepInfo.size(); ++I) {
+    if (I)
+      Targets += ',';
+    appendCIROffloadTarget(Targets, DepInfo[I].DependentOffloadKind,
+                           DepInfo[I].DependentToolChain,
+                           DepInfo[I].DependentBoundArch);
+  }
+  CmdArgs.push_back(TCArgs.MakeArgString(Targets));
+
+  CmdArgs.push_back(
+      TCArgs.MakeArgString(Twine("--input=") + Inputs.front().getFilename()));
+
+  for (unsigned I = 0; I < Outputs.size(); ++I) {
+    SmallString<128> Output;
+    Output += "--output=";
+    Output += DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
+    CmdArgs.push_back(TCArgs.MakeArgString(Output));
+  }
+
+  C.addCommand(std::make_unique<Command>(
+      JA, *this, ResponseFileSupport::None(),
+      TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),
+      CmdArgs, ArrayRef<InputInfo>(), Outputs));
+}
+
 void OffloadPackager::ConstructJob(Compilation &C, const JobAction &JA,
                                    const InputInfo &Output,
                                    const InputInfoList &Inputs,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9457,6 +9457,21 @@ static void appendCIROffloadTarget(SmallString<128> &Targets,
   }
 }
 
+static void addCIROffloadTargetsArg(
+    const llvm::opt::ArgList &TCArgs, ArgStringList &CmdArgs,
+    ArrayRef<JobActionWithDependentInfo::DependentActionInfo> DepInfo) {
+  SmallString<128> Targets;
+  Targets += "--targets=";
+  for (unsigned I = 0; I < DepInfo.size(); ++I) {
+    if (I)
+      Targets += ',';
+    appendCIROffloadTarget(Targets, DepInfo[I].DependentOffloadKind,
+                           DepInfo[I].DependentToolChain,
+                           DepInfo[I].DependentBoundArch);
+  }
+  CmdArgs.push_back(TCArgs.MakeArgString(Targets));
+}
+
 void CIROffloadMerge::ConstructJob(Compilation &C, const JobAction &JA,
                                    const InputInfo &Output,
                                    const InputInfoList &Inputs,
@@ -9469,17 +9484,7 @@ void CIROffloadMerge::ConstructJob(Compilation &C, const JobAction &JA,
 
   ArgStringList CmdArgs;
   CmdArgs.push_back("--combine");
-
-  SmallString<128> Targets;
-  Targets += "--targets=";
-  for (unsigned I = 0; I < DepInfo.size(); ++I) {
-    if (I)
-      Targets += ',';
-    appendCIROffloadTarget(Targets, DepInfo[I].DependentOffloadKind,
-                           DepInfo[I].DependentToolChain,
-                           DepInfo[I].DependentBoundArch);
-  }
-  CmdArgs.push_back(TCArgs.MakeArgString(Targets));
+  addCIROffloadTargetsArg(TCArgs, CmdArgs, DepInfo);
 
   CmdArgs.push_back(
       TCArgs.MakeArgString(Twine("--output=") + Output.getFilename()));
@@ -9509,17 +9514,7 @@ void CIROffloadMerge::ConstructJobMultipleOutputs(
 
   ArgStringList CmdArgs;
   CmdArgs.push_back("--split");
-
-  SmallString<128> Targets;
-  Targets += "--targets=";
-  for (unsigned I = 0; I < DepInfo.size(); ++I) {
-    if (I)
-      Targets += ',';
-    appendCIROffloadTarget(Targets, DepInfo[I].DependentOffloadKind,
-                           DepInfo[I].DependentToolChain,
-                           DepInfo[I].DependentBoundArch);
-  }
-  CmdArgs.push_back(TCArgs.MakeArgString(Targets));
+  addCIROffloadTargetsArg(TCArgs, CmdArgs, DepInfo);
 
   CmdArgs.push_back(
       TCArgs.MakeArgString(Twine("--input=") + Inputs.front().getFilename()));

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9250,6 +9250,50 @@ void ClangAs::ConstructJob(Compilation &C, const JobAction &JA,
 }
 
 // Begin OffloadBundler
+
+// Build the comma-separated "<flag>kind-triple[-arch],..." argument shared by
+// the offload (un)bundler and the CIR offload merge/split tools. The leading
+// flag differs per tool (e.g. "-targets=" vs "--targets=").
+static void addOffloadTargetsArg(
+    const llvm::opt::ArgList &TCArgs, ArgStringList &CmdArgs, StringRef Flag,
+    ArrayRef<JobActionWithDependentInfo::DependentActionInfo> DepInfo) {
+  SmallString<128> Triples;
+  Triples += Flag;
+  for (unsigned I = 0; I < DepInfo.size(); ++I) {
+    if (I)
+      Triples += ',';
+
+    const auto &Dep = DepInfo[I];
+    Triples += Action::GetOffloadKindName(Dep.DependentOffloadKind);
+    Triples += '-';
+    Triples += Dep.DependentToolChain->getTriple().normalize(
+        llvm::Triple::CanonicalForm::FOUR_IDENT);
+    if ((Dep.DependentOffloadKind == Action::OFK_HIP ||
+         Dep.DependentOffloadKind == Action::OFK_Cuda) &&
+        !Dep.DependentBoundArch.empty()) {
+      Triples += '-';
+      Triples += Dep.DependentBoundArch;
+    }
+    // TODO: Replace parsing of -march flag. Can be done by storing GPUArch
+    //       with each toolchain.
+    StringRef GPUArchName;
+    if (Dep.DependentOffloadKind == Action::OFK_OpenMP) {
+      // Extract GPUArch from -march argument in TC argument list.
+      for (unsigned ArgIndex = 0; ArgIndex < TCArgs.size(); ArgIndex++) {
+        StringRef ArchStr = StringRef(TCArgs.getArgString(ArgIndex));
+        auto Arch = ArchStr.starts_with_insensitive("-march=");
+        if (Arch) {
+          GPUArchName = ArchStr.substr(7);
+          Triples += "-";
+          break;
+        }
+      }
+      Triples += GPUArchName.str();
+    }
+  }
+  CmdArgs.push_back(TCArgs.MakeArgString(Triples));
+}
+
 void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
                                   const InputInfo &Output,
                                   const InputInfoList &Inputs,
@@ -9382,43 +9426,8 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       Twine("-type=") + types::getTypeTempSuffix(Input.getType())));
 
   // Get the targets.
-  SmallString<128> Triples;
-  Triples += "-targets=";
   auto DepInfo = UA.getDependentActionsInfo();
-  for (unsigned I = 0; I < DepInfo.size(); ++I) {
-    if (I)
-      Triples += ',';
-
-    auto &Dep = DepInfo[I];
-    Triples += Action::GetOffloadKindName(Dep.DependentOffloadKind);
-    Triples += '-';
-    Triples += Dep.DependentToolChain->getTriple().normalize(
-        llvm::Triple::CanonicalForm::FOUR_IDENT);
-    if ((Dep.DependentOffloadKind == Action::OFK_HIP ||
-         Dep.DependentOffloadKind == Action::OFK_Cuda) &&
-        !Dep.DependentBoundArch.empty()) {
-      Triples += '-';
-      Triples += Dep.DependentBoundArch;
-    }
-    // TODO: Replace parsing of -march flag. Can be done by storing GPUArch
-    //       with each toolchain.
-    StringRef GPUArchName;
-    if (Dep.DependentOffloadKind == Action::OFK_OpenMP) {
-      // Extract GPUArch from -march argument in TC argument list.
-      for (unsigned ArgIndex = 0; ArgIndex < TCArgs.size(); ArgIndex++) {
-        StringRef ArchStr = StringRef(TCArgs.getArgString(ArgIndex));
-        auto Arch = ArchStr.starts_with_insensitive("-march=");
-        if (Arch) {
-          GPUArchName = ArchStr.substr(7);
-          Triples += "-";
-          break;
-        }
-      }
-      Triples += GPUArchName.str();
-    }
-  }
-
-  CmdArgs.push_back(TCArgs.MakeArgString(Triples));
+  addOffloadTargetsArg(TCArgs, CmdArgs, "-targets=", DepInfo);
 
   // Get bundled file command.
   CmdArgs.push_back(
@@ -9443,30 +9452,6 @@ void OffloadBundler::ConstructJobMultipleOutputs(
       CmdArgs, ArrayRef<InputInfo>(), Outputs));
 }
 
-static void addCIROffloadTargetsArg(
-    const llvm::opt::ArgList &TCArgs, ArgStringList &CmdArgs,
-    ArrayRef<JobActionWithDependentInfo::DependentActionInfo> DepInfo) {
-  SmallString<128> Targets;
-  Targets += "--targets=";
-  for (unsigned I = 0; I < DepInfo.size(); ++I) {
-    const auto &Dep = DepInfo[I];
-    if (I)
-      Targets += ',';
-    Targets += Action::GetOffloadKindName(Dep.DependentOffloadKind);
-    Targets += '-';
-    Targets += Dep.DependentToolChain->getTriple().normalize(
-        llvm::Triple::CanonicalForm::FOUR_IDENT);
-    if ((Dep.DependentOffloadKind == Action::OFK_Cuda ||
-         Dep.DependentOffloadKind == Action::OFK_HIP ||
-         Dep.DependentOffloadKind == Action::OFK_OpenMP) &&
-        !Dep.DependentBoundArch.empty()) {
-      Targets += '-';
-      Targets += Dep.DependentBoundArch;
-    }
-  }
-  CmdArgs.push_back(TCArgs.MakeArgString(Targets));
-}
-
 void CIROffloadMerge::ConstructJob(Compilation &C, const JobAction &JA,
                                    const InputInfo &Output,
                                    const InputInfoList &Inputs,
@@ -9479,7 +9464,7 @@ void CIROffloadMerge::ConstructJob(Compilation &C, const JobAction &JA,
 
   ArgStringList CmdArgs;
   CmdArgs.push_back("--combine");
-  addCIROffloadTargetsArg(TCArgs, CmdArgs, DepInfo);
+  addOffloadTargetsArg(TCArgs, CmdArgs, "--targets=", DepInfo);
 
   CmdArgs.push_back(
       TCArgs.MakeArgString(Twine("--output=") + Output.getFilename()));
@@ -9509,7 +9494,7 @@ void CIROffloadMerge::ConstructJobMultipleOutputs(
 
   ArgStringList CmdArgs;
   CmdArgs.push_back("--split");
-  addCIROffloadTargetsArg(TCArgs, CmdArgs, DepInfo);
+  addOffloadTargetsArg(TCArgs, CmdArgs, "--targets=", DepInfo);
 
   CmdArgs.push_back(
       TCArgs.MakeArgString(Twine("--input=") + Inputs.front().getFilename()));

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9251,14 +9251,13 @@ void ClangAs::ConstructJob(Compilation &C, const JobAction &JA,
 
 // Begin OffloadBundler
 
-// Build the comma-separated "<flag>kind-triple[-arch],..." argument shared by
-// the offload (un)bundler and the CIR offload merge/split tools. The leading
-// flag differs per tool (e.g. "-targets=" vs "--targets=").
+// Build the comma-separated "-targets=kind-triple[-arch],..." argument shared by
+// the offload (un)bundler and the CIR offload merge/split tools.
 static void addOffloadTargetsArg(
-    const llvm::opt::ArgList &TCArgs, ArgStringList &CmdArgs, StringRef Flag,
+    const llvm::opt::ArgList &TCArgs, ArgStringList &CmdArgs,
     ArrayRef<JobActionWithDependentInfo::DependentActionInfo> DepInfo) {
   SmallString<128> Triples;
-  Triples += Flag;
+  Triples += "-targets=";
   for (unsigned I = 0; I < DepInfo.size(); ++I) {
     if (I)
       Triples += ',';
@@ -9427,7 +9426,7 @@ void OffloadBundler::ConstructJobMultipleOutputs(
 
   // Get the targets.
   auto DepInfo = UA.getDependentActionsInfo();
-  addOffloadTargetsArg(TCArgs, CmdArgs, "-targets=", DepInfo);
+  addOffloadTargetsArg(TCArgs, CmdArgs, DepInfo);
 
   // Get bundled file command.
   CmdArgs.push_back(
@@ -9463,15 +9462,15 @@ void CIROffloadMerge::ConstructJob(Compilation &C, const JobAction &JA,
          "Expected one target for each CIR merge input");
 
   ArgStringList CmdArgs;
-  CmdArgs.push_back("--combine");
-  addOffloadTargetsArg(TCArgs, CmdArgs, "--targets=", DepInfo);
+  CmdArgs.push_back("-combine");
+  addOffloadTargetsArg(TCArgs, CmdArgs, DepInfo);
 
   CmdArgs.push_back(
-      TCArgs.MakeArgString(Twine("--output=") + Output.getFilename()));
+      TCArgs.MakeArgString(Twine("-output=") + Output.getFilename()));
 
   for (unsigned I = 0; I < Inputs.size(); ++I) {
     SmallString<128> Input;
-    Input += "--input=";
+    Input += "-input=";
     Input += DepInfo[I].DependentToolChain->getInputFilename(Inputs[I]);
     CmdArgs.push_back(TCArgs.MakeArgString(Input));
   }
@@ -9493,15 +9492,15 @@ void CIROffloadMerge::ConstructJobMultipleOutputs(
          "Expected one CIR split output for each target");
 
   ArgStringList CmdArgs;
-  CmdArgs.push_back("--split");
-  addOffloadTargetsArg(TCArgs, CmdArgs, "--targets=", DepInfo);
+  CmdArgs.push_back("-split");
+  addOffloadTargetsArg(TCArgs, CmdArgs, DepInfo);
 
   CmdArgs.push_back(
-      TCArgs.MakeArgString(Twine("--input=") + Inputs.front().getFilename()));
+      TCArgs.MakeArgString(Twine("-input=") + Inputs.front().getFilename()));
 
   for (unsigned I = 0; I < Outputs.size(); ++I) {
     SmallString<128> Output;
-    Output += "--output=";
+    Output += "-output=";
     Output += DepInfo[I].DependentToolChain->getInputFilename(Outputs[I]);
     CmdArgs.push_back(TCArgs.MakeArgString(Output));
   }

--- a/clang/lib/Driver/ToolChains/Clang.h
+++ b/clang/lib/Driver/ToolChains/Clang.h
@@ -159,6 +159,24 @@ public:
                                    const char *LinkingOutput) const override;
 };
 
+/// CIR offload merge tool.
+class LLVM_LIBRARY_VISIBILITY CIROffloadMerge final : public Tool {
+public:
+  CIROffloadMerge(const ToolChain &TC)
+      : Tool("CIR offload merge", "cir-offload-merge", TC) {}
+
+  bool hasIntegratedCPP() const override { return false; }
+  void ConstructJob(Compilation &C, const JobAction &JA,
+                    const InputInfo &Output, const InputInfoList &Inputs,
+                    const llvm::opt::ArgList &TCArgs,
+                    const char *LinkingOutput) const override;
+  void ConstructJobMultipleOutputs(Compilation &C, const JobAction &JA,
+                                   const InputInfoList &Outputs,
+                                   const InputInfoList &Inputs,
+                                   const llvm::opt::ArgList &TCArgs,
+                                   const char *LinkingOutput) const override;
+};
+
 /// Offload binary tool.
 class LLVM_LIBRARY_VISIBILITY OffloadPackager final : public Tool {
 public:

--- a/clang/test/CIR/Tools/cir-offload-merge.cir
+++ b/clang/test/CIR/Tools/cir-offload-merge.cir
@@ -1,10 +1,10 @@
 // RUN: rm -rf %t && split-file %s %t
 
-// RUN: cir-offload-merge --combine \
-// RUN:   --input=%t/host.cir \
-// RUN:   --input=%t/device-sm80.cir \
-// RUN:   --targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 \
-// RUN:   --output=%t/combined.cir
+// RUN: cir-offload-merge -combine \
+// RUN:   -input=%t/host.cir \
+// RUN:   -input=%t/device-sm80.cir \
+// RUN:   -targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 \
+// RUN:   -output=%t/combined.cir
 // RUN: FileCheck %s --check-prefix=BASIC --input-file=%t/combined.cir
 // RUN: cir-opt %t/combined.cir --verify-roundtrip -o /dev/null
 
@@ -12,11 +12,11 @@
 // BASIC-NEXT: builtin.module @host attributes {cir.offload.bundle_id = "host-x86_64-unknown-linux-gnu", cir.offload.kind = #cir.offload_kind<host>, cir.triple = "x86_64-unknown-linux-gnu"} {
 // BASIC: builtin.module @device_cuda_nvptx64_nvidia_cuda__sm_80 attributes {cir.offload.bundle_id = "cuda-nvptx64-nvidia-cuda--sm_80", cir.offload.kind = #cir.offload_kind<device>, cir.triple = "nvptx64-nvidia-cuda"} {
 
-// RUN: cir-offload-merge --split \
-// RUN:   --input=%t/combined.cir \
-// RUN:   --targets=cuda-nvptx64-nvidia-cuda--sm_80,host-x86_64-unknown-linux-gnu \
-// RUN:   --output=%t/split-device-sm80.cir \
-// RUN:   --output=%t/split-host.cir
+// RUN: cir-offload-merge -split \
+// RUN:   -input=%t/combined.cir \
+// RUN:   -targets=cuda-nvptx64-nvidia-cuda--sm_80,host-x86_64-unknown-linux-gnu \
+// RUN:   -output=%t/split-device-sm80.cir \
+// RUN:   -output=%t/split-host.cir
 // RUN: FileCheck %s --check-prefix=SPLIT-HOST --implicit-check-not=cir.offload.container --input-file=%t/split-host.cir
 // RUN: FileCheck %s --check-prefix=SPLIT-SM80 --implicit-check-not=cir.offload.container --input-file=%t/split-device-sm80.cir
 // RUN: cir-opt %t/split-host.cir --verify-roundtrip -o /dev/null
@@ -25,12 +25,12 @@
 // SPLIT-HOST: module @host attributes {cir.offload.bundle_id = "host-x86_64-unknown-linux-gnu", cir.offload.kind = #cir.offload_kind<host>, cir.triple = "x86_64-unknown-linux-gnu"} {
 // SPLIT-SM80: module @device_cuda_nvptx64_nvidia_cuda__sm_80 attributes {cir.offload.bundle_id = "cuda-nvptx64-nvidia-cuda--sm_80", cir.offload.kind = #cir.offload_kind<device>, cir.triple = "nvptx64-nvidia-cuda"} {
 
-// RUN: cir-offload-merge --combine \
-// RUN:   --input=%t/device-sm90.cir \
-// RUN:   --input=%t/host.cir \
-// RUN:   --input=%t/device-sm80.cir \
-// RUN:   --targets=cuda-nvptx64-nvidia-cuda--sm_90,host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 \
-// RUN:   --output=%t/reordered.cir
+// RUN: cir-offload-merge -combine \
+// RUN:   -input=%t/device-sm90.cir \
+// RUN:   -input=%t/host.cir \
+// RUN:   -input=%t/device-sm80.cir \
+// RUN:   -targets=cuda-nvptx64-nvidia-cuda--sm_90,host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 \
+// RUN:   -output=%t/reordered.cir
 // RUN: FileCheck %s --check-prefix=REORDER --input-file=%t/reordered.cir
 // RUN: cir-opt %t/reordered.cir --verify-roundtrip -o /dev/null
 
@@ -39,105 +39,105 @@
 // REORDER: builtin.module @device_cuda_nvptx64_nvidia_cuda__sm_90
 // REORDER: builtin.module @device_cuda_nvptx64_nvidia_cuda__sm_80
 
-// RUN: cir-offload-merge --split \
-// RUN:   --input=%t/reordered.cir \
-// RUN:   --targets=cuda-nvptx64-nvidia-cuda--sm_80,host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_90 \
-// RUN:   --output=%t/split-reordered-sm80.cir \
-// RUN:   --output=%t/split-reordered-host.cir \
-// RUN:   --output=%t/split-reordered-sm90.cir
+// RUN: cir-offload-merge -split \
+// RUN:   -input=%t/reordered.cir \
+// RUN:   -targets=cuda-nvptx64-nvidia-cuda--sm_80,host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_90 \
+// RUN:   -output=%t/split-reordered-sm80.cir \
+// RUN:   -output=%t/split-reordered-host.cir \
+// RUN:   -output=%t/split-reordered-sm90.cir
 // RUN: FileCheck %s --check-prefix=SPLIT-HOST --implicit-check-not=cir.offload.container --input-file=%t/split-reordered-host.cir
 // RUN: FileCheck %s --check-prefix=SPLIT-SM80 --implicit-check-not=cir.offload.container --input-file=%t/split-reordered-sm80.cir
 // RUN: FileCheck %s --check-prefix=SPLIT-SM90 --implicit-check-not=cir.offload.container --input-file=%t/split-reordered-sm90.cir
 
 // SPLIT-SM90: module @device_cuda_nvptx64_nvidia_cuda__sm_90 attributes {cir.offload.bundle_id = "cuda-nvptx64-nvidia-cuda--sm_90", cir.offload.kind = #cir.offload_kind<device>} {
 
-// RUN: cir-offload-merge --split \
-// RUN:   --input=%t/compatible-target-id.cir \
-// RUN:   --targets=hip-amdgcn-amd-amdhsa--gfx908:xnack+ \
-// RUN:   --output=%t/split-compatible-hip.cir
+// RUN: cir-offload-merge -split \
+// RUN:   -input=%t/compatible-target-id.cir \
+// RUN:   -targets=hip-amdgcn-amd-amdhsa--gfx908:xnack+ \
+// RUN:   -output=%t/split-compatible-hip.cir
 // RUN: FileCheck %s --check-prefix=SPLIT-COMPATIBLE-HIP --implicit-check-not=cir.offload.container --input-file=%t/split-compatible-hip.cir
 
 // SPLIT-COMPATIBLE-HIP: module @device_gfx908 attributes {cir.offload.bundle_id = "hip-amdgcn-amd-amdhsa--gfx908", cir.offload.kind = #cir.offload_kind<device>} {
 
-// RUN: not cir-offload-merge --input=%t/host.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-MODE
-// ERR-NO-MODE: error: expected exactly one of --combine or --split
+// RUN: not cir-offload-merge -input=%t/host.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-MODE
+// ERR-NO-MODE: error: expected exactly one of -combine or -split
 
-// RUN: not cir-offload-merge --combine --split --input=%t/host.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-BOTH-MODES
-// ERR-BOTH-MODES: error: expected exactly one of --combine or --split
+// RUN: not cir-offload-merge -combine -split -input=%t/host.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-BOTH-MODES
+// ERR-BOTH-MODES: error: expected exactly one of -combine or -split
 
-// RUN: not cir-offload-merge --combine --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-INPUT
-// ERR-NO-INPUT: error: missing required --input
+// RUN: not cir-offload-merge -combine -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-INPUT
+// ERR-NO-INPUT: error: missing required -input
 
-// RUN: not cir-offload-merge --combine --input=%t/host.cir --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-TARGETS
-// ERR-NO-TARGETS: error: missing required --targets
+// RUN: not cir-offload-merge -combine -input=%t/host.cir -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-TARGETS
+// ERR-NO-TARGETS: error: missing required -targets
 
-// RUN: not cir-offload-merge --combine --input=%t/host.cir --targets=host-x86_64-unknown-linux-gnu 2>&1 | FileCheck %s --check-prefix=ERR-NO-OUTPUT
-// ERR-NO-OUTPUT: error: missing required --output
+// RUN: not cir-offload-merge -combine -input=%t/host.cir -targets=host-x86_64-unknown-linux-gnu 2>&1 | FileCheck %s --check-prefix=ERR-NO-OUTPUT
+// ERR-NO-OUTPUT: error: missing required -output
 
-// RUN: not cir-offload-merge --combine --input=%t/host.cir --input=%t/device-sm80.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-COUNT
+// RUN: not cir-offload-merge -combine -input=%t/host.cir -input=%t/device-sm80.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-COUNT
 // ERR-COUNT: error: number of input files and targets should match in combine mode
 
-// RUN: not cir-offload-merge --combine --input=%t/host.cir --targets=not-a-target --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-BAD-TARGET
+// RUN: not cir-offload-merge -combine -input=%t/host.cir -targets=not-a-target -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-BAD-TARGET
 // ERR-BAD-TARGET: error: invalid target 'not-a-target'
 
-// RUN: not cir-offload-merge --combine --input=%t/host.cir --input=%t/device-sm80.cir --targets=cuda-nvptx64-nvidia-cuda--sm_80,cuda-nvptx64-nvidia-cuda--sm_80 --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-DUP
+// RUN: not cir-offload-merge -combine -input=%t/host.cir -input=%t/device-sm80.cir -targets=cuda-nvptx64-nvidia-cuda--sm_80,cuda-nvptx64-nvidia-cuda--sm_80 -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-DUP
 // ERR-DUP: error: duplicate target 'cuda-nvptx64-nvidia-cuda--sm_80'
 
-// RUN: not cir-offload-merge --combine --input=%t/device-sm80.cir --targets=cuda-nvptx64-nvidia-cuda--sm_80 --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-HOST
+// RUN: not cir-offload-merge -combine -input=%t/device-sm80.cir -targets=cuda-nvptx64-nvidia-cuda--sm_80 -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-HOST
 // ERR-NO-HOST: error: expected exactly one host target
 
-// RUN: not cir-offload-merge --combine --input=%t/host.cir --input=%t/host2.cir --targets=host-x86_64-unknown-linux-gnu,host-aarch64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-MULTI-HOST
+// RUN: not cir-offload-merge -combine -input=%t/host.cir -input=%t/host2.cir -targets=host-x86_64-unknown-linux-gnu,host-aarch64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-MULTI-HOST
 // ERR-MULTI-HOST: error: expected exactly one host target
 
-// RUN: not cir-offload-merge --combine --input=%t/host.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-DEVICE
+// RUN: not cir-offload-merge -combine -input=%t/host.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-NO-DEVICE
 // ERR-NO-DEVICE: error: expected at least one device target
 
-// RUN: not cir-offload-merge --combine --input=%t/invalid.cir --input=%t/device-sm80.cir --targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-PARSE
+// RUN: not cir-offload-merge -combine -input=%t/invalid.cir -input=%t/device-sm80.cir -targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-PARSE
 // ERR-PARSE: error: failed to parse input file
 
-// RUN: not cir-offload-merge --split --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-INPUT
-// ERR-SPLIT-NO-INPUT: error: missing required --input
+// RUN: not cir-offload-merge -split -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-INPUT
+// ERR-SPLIT-NO-INPUT: error: missing required -input
 
-// RUN: not cir-offload-merge --split --input=%t/combined.cir --input=%t/combined.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-MULTI-INPUT
+// RUN: not cir-offload-merge -split -input=%t/combined.cir -input=%t/combined.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-MULTI-INPUT
 // ERR-SPLIT-MULTI-INPUT: error: split mode expects exactly one input
 
-// RUN: not cir-offload-merge --split --input=%t/combined.cir --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-TARGETS
-// ERR-SPLIT-NO-TARGETS: error: missing required --targets
+// RUN: not cir-offload-merge -split -input=%t/combined.cir -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-TARGETS
+// ERR-SPLIT-NO-TARGETS: error: missing required -targets
 
-// RUN: not cir-offload-merge --split --input=%t/combined.cir --targets=host-x86_64-unknown-linux-gnu 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-OUTPUT
-// ERR-SPLIT-NO-OUTPUT: error: missing required --output
+// RUN: not cir-offload-merge -split -input=%t/combined.cir -targets=host-x86_64-unknown-linux-gnu 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-OUTPUT
+// ERR-SPLIT-NO-OUTPUT: error: missing required -output
 
-// RUN: not cir-offload-merge --split --input=%t/combined.cir --targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-COUNT
+// RUN: not cir-offload-merge -split -input=%t/combined.cir -targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-COUNT
 // ERR-SPLIT-COUNT: error: number of output files and targets should match in split mode
 
-// RUN: not cir-offload-merge --split --input=%t/combined.cir --targets=host-x86_64-unknown-linux-gnu,host-x86_64-unknown-linux-gnu --output=%t/host0.cir --output=%t/host1.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-DUP-TARGET
+// RUN: not cir-offload-merge -split -input=%t/combined.cir -targets=host-x86_64-unknown-linux-gnu,host-x86_64-unknown-linux-gnu -output=%t/host0.cir -output=%t/host1.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-DUP-TARGET
 // ERR-SPLIT-DUP-TARGET: error: duplicate target 'host-x86_64-unknown-linux-gnu'
 
-// RUN: not cir-offload-merge --split --input=%t/combined.cir --targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 --output=%t/out.cir --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-DUP-OUTPUT
+// RUN: not cir-offload-merge -split -input=%t/combined.cir -targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 -output=%t/out.cir -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-DUP-OUTPUT
 // ERR-SPLIT-DUP-OUTPUT: error: duplicate output
 
-// RUN: not cir-offload-merge --split --input=%t/host.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-CONTAINER
+// RUN: not cir-offload-merge -split -input=%t/host.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-NO-CONTAINER
 // ERR-SPLIT-NO-CONTAINER: error: expected exactly one direct top-level cir.offload.container
 
-// RUN: not cir-offload-merge --split --input=%t/multi-container.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-MULTI-CONTAINER
+// RUN: not cir-offload-merge -split -input=%t/multi-container.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-MULTI-CONTAINER
 // ERR-SPLIT-MULTI-CONTAINER: error: expected exactly one direct top-level cir.offload.container
 
-// RUN: not cir-offload-merge --split --input=%t/invalid.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-PARSE
+// RUN: not cir-offload-merge -split -input=%t/invalid.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-PARSE
 
-// RUN: not cir-offload-merge --split --input=%t/invalid-container.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-VERIFY
+// RUN: not cir-offload-merge -split -input=%t/invalid-container.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-SPLIT-VERIFY
 // ERR-SPLIT-VERIFY: 'cir.offload.container' op expects at least one device module
 // ERR-SPLIT-VERIFY: error: failed to parse input file
 
-// RUN: not cir-offload-merge --split --input=%t/missing-bundle-id.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-MISSING-BUNDLE-ID
+// RUN: not cir-offload-merge -split -input=%t/missing-bundle-id.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-MISSING-BUNDLE-ID
 // ERR-MISSING-BUNDLE-ID: error: nested module is missing 'cir.offload.bundle_id'
 
-// RUN: not cir-offload-merge --split --input=%t/combined.cir --targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_90 --output=%t/host.cir --output=%t/sm90.cir 2>&1 | FileCheck %s --check-prefix=ERR-MISSING-TARGET
+// RUN: not cir-offload-merge -split -input=%t/combined.cir -targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_90 -output=%t/host.cir -output=%t/sm90.cir 2>&1 | FileCheck %s --check-prefix=ERR-MISSING-TARGET
 // ERR-MISSING-TARGET: error: can't find module for target 'cuda-nvptx64-nvidia-cuda--sm_90'
 
-// RUN: not cir-offload-merge --split --input=%t/duplicate-bundle-id.cir --targets=host-x86_64-unknown-linux-gnu --output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-DUP-BUNDLE-ID
+// RUN: not cir-offload-merge -split -input=%t/duplicate-bundle-id.cir -targets=host-x86_64-unknown-linux-gnu -output=%t/out.cir 2>&1 | FileCheck %s --check-prefix=ERR-DUP-BUNDLE-ID
 // ERR-DUP-BUNDLE-ID: error: duplicate module bundle ID 'host-x86_64-unknown-linux-gnu'
 
-// RUN: not cir-offload-merge --split --input=%t/compatible-target-id.cir --targets=hip-amdgcn-amd-amdhsa--gfx908:xnack+,hip-amdgcn-amd-amdhsa--gfx908:sramecc+ --output=%t/xnack.cir --output=%t/sramecc.cir 2>&1 | FileCheck %s --check-prefix=ERR-MULTI-MATCH
+// RUN: not cir-offload-merge -split -input=%t/compatible-target-id.cir -targets=hip-amdgcn-amd-amdhsa--gfx908:xnack+,hip-amdgcn-amd-amdhsa--gfx908:sramecc+ -output=%t/xnack.cir -output=%t/sramecc.cir 2>&1 | FileCheck %s --check-prefix=ERR-MULTI-MATCH
 // ERR-MULTI-MATCH: error: module bundle ID 'hip-amdgcn-amd-amdhsa--gfx908' matches multiple requested targets
 
 //--- host.cir

--- a/clang/tools/cir-offload-merge/cir-offload-merge.cpp
+++ b/clang/tools/cir-offload-merge/cir-offload-merge.cpp
@@ -163,13 +163,13 @@ bool isCompatibleTarget(llvm::StringRef bundleID, llvm::StringRef target,
 int validateCombineCommandLine(
     llvm::SmallVectorImpl<InputTarget> &inputTargets) {
   if (Combine == Split)
-    return reportError("expected exactly one of --combine or --split");
+    return reportError("expected exactly one of -combine or -split");
   if (InputFileNames.empty())
-    return reportError("missing required --input");
+    return reportError("missing required -input");
   if (TargetNames.empty())
-    return reportError("missing required --targets");
+    return reportError("missing required -targets");
   if (OutputFileNames.empty())
-    return reportError("missing required --output");
+    return reportError("missing required -output");
   if (OutputFileNames.size() != 1)
     return reportError("combine mode expects exactly one output");
   if (InputFileNames.size() != TargetNames.size())
@@ -209,15 +209,15 @@ int validateCombineCommandLine(
 int validateSplitCommandLine(
     llvm::SmallVectorImpl<TargetOutput> &targetOutputs) {
   if (Combine == Split)
-    return reportError("expected exactly one of --combine or --split");
+    return reportError("expected exactly one of -combine or -split");
   if (InputFileNames.empty())
-    return reportError("missing required --input");
+    return reportError("missing required -input");
   if (InputFileNames.size() != 1)
     return reportError("split mode expects exactly one input");
   if (TargetNames.empty())
-    return reportError("missing required --targets");
+    return reportError("missing required -targets");
   if (OutputFileNames.empty())
-    return reportError("missing required --output");
+    return reportError("missing required -output");
   if (OutputFileNames.size() != TargetNames.size())
     return reportError("number of output files and targets should match in "
                        "split mode");
@@ -367,7 +367,7 @@ int splitInput(llvm::StringRef inputFileName,
       return reportError(llvm::Twine("invalid module bundle ID '") + bundleID +
                          "'");
 
-    // The requested --targets/--output pairs only form the output map. The
+    // The requested -targets/-output pairs only form the output map. The
     // stored bundle ID decides where this nested module is written.
     TargetOutput *match = nullptr;
     for (TargetOutput &targetOutput : targetOutputs) {


### PR DESCRIPTION
This is mostly the initial scaffold of the actions we will work with to handle the tool invocations. Both actions represent their expected input and output sizes. I've made sure both `CIRSplitJobAction` and `CIRMergeJobAction` resemble nearly verbatim (in structure) to the offload bundler which as discussed at least from the driver perspective is our source of truth.

Two new `ActionClass` entries (`CIRMergeJobClass` and `CIRSplitJobClass`) are introduced alongside their corresponding `JobAction` subclasses. `CIRMergeJobAction` takes a list of CIR inputs and produces a single merged CIR output, while `CIRSplitJobAction` takes a single CIR input and produces multiple per-target outputs. Both carry `DependentActionInfo` (toolchain, bound arch, offload kind) to drive target string construction.

The `CIROffloadMerge` tool implements `ConstructJob` for the merge and split paths with the conventions we established in: https://github.com/RiverDave/llvm-project/pull/3 and https://github.com/RiverDave/llvm-project/pull/4

Note:
Note that this merely introduces the action definitions, how the `cir-offload-merge` maps to these and how to handle tool invocations - the proper action construction/testing is deferred for later PR's.