### PR TITLE
[CIR] Construct the offload merge driver pipeline for CUDA (single arch)

### DIFF
--- a/clang/include/clang/Options/Options.td
+++ b/clang/include/clang/Options/Options.td
@@ -3408,6 +3408,9 @@ defm clangir : BoolFOption<"clangir",
   PosFlag<SetTrue, [], [ClangOption, CC1Option], "Use the ClangIR pipeline to compile">,
   NegFlag<SetFalse, [], [ClangOption, CC1Option], "Use the AST -> LLVM pipeline to compile">,
   BothFlags<[], [ClangOption, CC1Option], "">>;
+def clangir_offload_merge : Flag<["--"], "clangir-offload-merge">,
+  Visibility<[ClangOption]>,
+  HelpText<"Merge serialized ClangIR host/device offload modules before backend compilation.">;
 def emit_cir : Flag<["-"], "emit-cir">, Visibility<[ClangOption, CC1Option]>,
   Group<Action_Group>, HelpText<"Build ASTs and then lower to ClangIR">;
 /// ClangIR-specific options - END

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -68,6 +68,14 @@ void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch,
   // Offload action set its own kinds on their dependences.
   if (Kind == OffloadClass)
     return;
+  if (Kind == CIRSplitJobClass) {
+    assert((OffloadingDeviceKind == OKind || OffloadingDeviceKind == OFK_None) &&
+           "Setting device kind to a different device??");
+    OffloadingDeviceKind = OKind;
+    OffloadingArch = OArch;
+    OffloadingToolChain = OToolChain;
+    return;
+  }
   // Unbundling actions use the host kinds.
   if (Kind == OffloadUnbundlingJobClass)
     return;
@@ -86,6 +94,8 @@ void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch,
 void Action::propagateHostOffloadInfo(unsigned OKinds, const char *OArch) {
   // Offload action set its own kinds on their dependences.
   if (Kind == OffloadClass)
+    return;
+  if (Kind == CIRSplitJobClass)
     return;
 
   assert(OffloadingDeviceKind == OFK_None &&

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -68,7 +68,9 @@ void Action::propagateDeviceOffloadInfo(OffloadKind OKind, const char *OArch,
   // Offload action set its own kinds on their dependences.
   if (Kind == OffloadClass)
     return;
-  if (Kind == CIRSplitJobClass) {
+  // Merge/split mix host and device inputs; stamp the node itself but do not
+  // recurse, so device info never bleeds into the host CIR compile.
+  if (Kind == CIRSplitJobClass || Kind == CIRMergeJobClass) {
     assert((OffloadingDeviceKind == OKind || OffloadingDeviceKind == OFK_None) &&
            "Setting device kind to a different device??");
     OffloadingDeviceKind = OKind;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5080,6 +5080,11 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
   if (isCIROffloadMerge(C, Args) && !Args.hasArg(options::OPT_emit_cir) &&
       isa<CompileJobAction>(HostAction) &&
       HostAction->getType() == types::TY_CIR) {
+    // TODO: HIP needs the device fatbin bundling step before the host embed;
+    // wired up in a follow-up. Until then only CUDA is supported here.
+    assert(!C.isOffloadingHostKind(Action::OFK_HIP) &&
+           "ClangIR offload merge for HIP is NYI");
+
     ActionList MergeInputs;
     MergeInputs.push_back(HostAction);
 
@@ -6466,12 +6471,6 @@ InputInfoList Driver::BuildJobsForActionNoCache(
     if (T->canEmitIR())
       handleTimeTrace(C, Args, JA, BaseInput, Result);
   }
-
-  if (TargetDeviceOffloadKind != Action::OFK_None &&
-      TargetDeviceOffloadKind != Action::OFK_Host &&
-      JA->getOffloadingDeviceKind() == Action::OFK_None)
-    const_cast<JobAction *>(JA)->propagateDeviceOffloadInfo(
-        TargetDeviceOffloadKind, BoundArch.data(), TC);
 
   if (CCCPrintBindings && !CCGenDiagnostics) {
     llvm::errs() << "# \"" << T->getToolChain().getEffectiveTriple().str()

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6472,6 +6472,17 @@ InputInfoList Driver::BuildJobsForActionNoCache(
       handleTimeTrace(C, Args, JA, BaseInput, Result);
   }
 
+  // The CIR offload-merge split feeds device modules back through -x cir
+  // without re-tagging the resulting backend actions, so their device offload
+  // kind is unset by the time the tool builds the cc1 command below. Stamp it
+  // here so the device tool chain (e.g. NVPTX) sees a valid offload kind.
+  if (isCIROffloadMerge(C, C.getArgs()) &&
+      TargetDeviceOffloadKind != Action::OFK_None &&
+      TargetDeviceOffloadKind != Action::OFK_Host &&
+      JA->getOffloadingDeviceKind() == Action::OFK_None)
+    const_cast<JobAction *>(JA)->propagateDeviceOffloadInfo(
+        TargetDeviceOffloadKind, BoundArch.data(), TC);
+
   if (CCCPrintBindings && !CCGenDiagnostics) {
     llvm::errs() << "# \"" << T->getToolChain().getEffectiveTriple().str()
                  << '"' << " - \"" << T->getName() << "\", inputs: [";

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4520,6 +4520,16 @@ shouldBundleHIPAsmWithNewDriver(const Compilation &C,
   return HasAMDGCNHIPDevice;
 }
 
+// True when the ClangIR host/device offload-merge pipeline is requested for a
+// CUDA/HIP compilation.
+static bool isCIROffloadMerge(const Compilation &C,
+                              const llvm::opt::ArgList &Args) {
+  return Args.hasArg(options::OPT_fclangir) &&
+         Args.hasArg(options::OPT_clangir_offload_merge) &&
+         (C.isOffloadingHostKind(Action::OFK_Cuda) ||
+          C.isOffloadingHostKind(Action::OFK_HIP));
+}
+
 void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
                           const InputList &Inputs, ActionList &Actions) const {
   llvm::PrettyStackTraceString CrashInfo("Building compilation actions");
@@ -4616,9 +4626,37 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       // later actions in the same command line?
 
       // Otherwise construct the appropriate action.
-      Action *NewCurrent =
-          ConstructPhaseAction(C, Args, Phase, Current, Action::OFK_None,
-                               C.getDefaultToolChain().getLTOMode(Args));
+      Action *NewCurrent = nullptr;
+      // CIR offload split produces host/device CIR dependences under one
+      // OffloadAction. Apply backend phases to each dependence separately.
+      if (isCIROffloadMerge(C, Args) &&
+          (Phase == phases::Backend || Phase == phases::Assemble))
+        if (auto *OA = dyn_cast<OffloadAction>(Current)) {
+          Action *HostAction = OA->getHostDependence();
+          HostAction = ConstructPhaseAction(C, Args, Phase, HostAction);
+
+          OffloadAction::DeviceDependences DDeps;
+          OA->doOnEachDeviceDependence(
+              [&](Action *DepA, const ToolChain *DepTC,
+                  const char *DepBoundArch) {
+                Action::OffloadKind Kind = DepA->getOffloadingDeviceKind();
+                Action *DeviceAction =
+                    ConstructPhaseAction(C, Args, Phase, DepA, Kind);
+                DeviceAction->propagateDeviceOffloadInfo(Kind, DepBoundArch,
+                                                         DepTC);
+                DDeps.add(*DeviceAction, *DepTC, DepBoundArch, Kind);
+              });
+
+          OffloadAction::HostDependence HDep(
+              *HostAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
+              /*BoundArch=*/nullptr, DDeps);
+          NewCurrent = C.MakeAction<OffloadAction>(HDep, DDeps);
+        }
+
+      if (!NewCurrent)
+        NewCurrent =
+            ConstructPhaseAction(C, Args, Phase, Current, Action::OFK_None,
+                                 C.getDefaultToolChain().getLTOMode(Args));
 
       // We didn't create a new action, so we will just move to the next phase.
       if (NewCurrent == Current)
@@ -5037,6 +5075,84 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
         getFinalPhase(Args) == phases::Preprocess))
     return HostAction;
 
+  // For CUDA/HIP with ClangIR, merge serialized host/device CIR modules and
+  // split them again before the backend consumes each module with -x cir.
+  if (isCIROffloadMerge(C, Args) && !Args.hasArg(options::OPT_emit_cir) &&
+      isa<CompileJobAction>(HostAction) &&
+      HostAction->getType() == types::TY_CIR) {
+    ActionList MergeInputs;
+    MergeInputs.push_back(HostAction);
+
+    struct CIROffloadDep final {
+      const ToolChain *TC = nullptr;
+      StringRef BoundArch;
+      Action::OffloadKind Kind = Action::OFK_None;
+    };
+    SmallVector<CIROffloadDep, 6> Deps;
+    Deps.push_back({C.getSingleOffloadToolChain<Action::OFK_Host>(),
+                    StringRef(), Action::OFK_Host});
+
+    const Action::OffloadKind CIRKinds[] = {Action::OFK_Cuda,
+                                            Action::OFK_HIP};
+    for (Action::OffloadKind Kind : CIRKinds) {
+      if ((Kind == Action::OFK_Cuda && !types::isCuda(Input.first)) ||
+          (Kind == Action::OFK_HIP && !types::isHIP(Input.first)))
+        continue;
+
+      SmallVector<const ToolChain *, 2> ToolChains;
+      auto TCRange = C.getOffloadToolChains(Kind);
+      for (auto TI = TCRange.first, TE = TCRange.second; TI != TE; ++TI)
+        ToolChains.push_back(TI->second);
+
+      for (const ToolChain *TC : ToolChains) {
+        for (StringRef Arch : getOffloadArchs(C, C.getArgs(), Kind, *TC)) {
+          types::ID DeviceInputType =
+              Kind == Action::OFK_HIP ? types::TY_HIP_DEVICE
+                                      : types::TY_CUDA_DEVICE;
+          Action *DeviceAction =
+              C.MakeAction<InputAction>(*Input.second, DeviceInputType, CUID);
+          DeviceAction->propagateDeviceOffloadInfo(Kind, Arch.data(), TC);
+
+          auto PL = types::getCompilationPhases(*this, Args, DeviceInputType);
+          for (phases::ID Phase : PL) {
+            if (Phase == phases::Link)
+              break;
+            DeviceAction = ConstructPhaseAction(C, Args, Phase, DeviceAction,
+                                                Kind);
+            if (Phase == phases::Compile)
+              break;
+          }
+
+          if (DeviceAction->getType() != types::TY_CIR)
+            return HostAction;
+
+          MergeInputs.push_back(DeviceAction);
+          Deps.push_back({TC, Arch, Kind});
+        }
+      }
+    }
+
+    if (MergeInputs.size() == 1)
+      return HostAction;
+
+    auto *Merge = C.MakeAction<CIRMergeJobAction>(MergeInputs);
+    for (const CIROffloadDep &Dep : Deps)
+      Merge->registerDependentActionInfo(Dep.TC, Dep.BoundArch, Dep.Kind);
+
+    auto *Split = C.MakeAction<CIRSplitJobAction>(Merge);
+    for (const CIROffloadDep &Dep : Deps)
+      Split->registerDependentActionInfo(Dep.TC, Dep.BoundArch, Dep.Kind);
+
+    OffloadAction::DeviceDependences DDeps;
+    for (const CIROffloadDep &Dep : ArrayRef(Deps).drop_front())
+      DDeps.add(*Split, *Dep.TC, Dep.BoundArch.data(), Dep.Kind);
+
+    OffloadAction::HostDependence HDep(
+        *Split, *C.getSingleOffloadToolChain<Action::OFK_Host>(),
+        /*BoundArch=*/nullptr, DDeps);
+    return C.MakeAction<OffloadAction>(HDep, DDeps);
+  }
+
   ActionList OffloadActions;
   OffloadAction::DeviceDependences DDeps;
 
@@ -5350,6 +5466,8 @@ Action *Driver::ConstructPhaseAction(
     if (Args.hasArg(options::OPT_emit_ast))
       return C.MakeAction<CompileJobAction>(Input, types::TY_AST);
     if (Args.hasArg(options::OPT_emit_cir))
+      return C.MakeAction<CompileJobAction>(Input, types::TY_CIR);
+    if (isCIROffloadMerge(C, Args))
       return C.MakeAction<CompileJobAction>(Input, types::TY_CIR);
     if (Args.hasArg(options::OPT_module_file_info))
       return C.MakeAction<CompileJobAction>(Input, types::TY_ModuleFile);
@@ -6182,15 +6300,33 @@ InputInfoList Driver::BuildJobsForActionNoCache(
 
   // Only use pipes when there is exactly one input.
   InputInfoList InputInfos;
-  for (const Action *Input : Inputs) {
-    // Treat dsymutil and verify sub-jobs as being at the top-level too, they
-    // shouldn't get temporary output names.
-    // FIXME: Clean this up.
-    bool SubJobAtTopLevel =
-        AtTopLevel && (isa<DsymutilJobAction>(A) || isa<VerifyJobAction>(A));
-    InputInfos.append(BuildJobsForAction(
-        C, Input, TC, BoundArch, SubJobAtTopLevel, MultipleArchs, LinkingOutput,
-        CachedResults, A->getOffloadingDeviceKind()));
+  if (const auto *MA = dyn_cast<CIRMergeJobAction>(JA)) {
+    auto DepInfo = MA->getDependentActionsInfo();
+    assert(Inputs.size() == DepInfo.size() &&
+           "Expected one target for each CIR merge input");
+    for (unsigned I = 0; I < Inputs.size(); ++I) {
+      const auto &Dep = DepInfo[I];
+      Action::OffloadKind BuildKind =
+          Dep.DependentOffloadKind == Action::OFK_Host
+              ? Action::OFK_None
+              : Dep.DependentOffloadKind;
+      InputInfos.append(BuildJobsForAction(
+          C, Inputs[I], Dep.DependentToolChain, Dep.DependentBoundArch,
+          /*AtTopLevel=*/false,
+          /*MultipleArchs=*/!Dep.DependentBoundArch.empty(),
+          LinkingOutput, CachedResults, BuildKind));
+    }
+  } else {
+    for (const Action *Input : Inputs) {
+      // Treat dsymutil and verify sub-jobs as being at the top-level too, they
+      // shouldn't get temporary output names.
+      // FIXME: Clean this up.
+      bool SubJobAtTopLevel =
+          AtTopLevel && (isa<DsymutilJobAction>(A) || isa<VerifyJobAction>(A));
+      InputInfos.append(BuildJobsForAction(
+          C, Input, TC, BoundArch, SubJobAtTopLevel, MultipleArchs,
+          LinkingOutput, CachedResults, A->getOffloadingDeviceKind()));
+    }
   }
 
   // Always use the first file input as the base input.
@@ -6279,6 +6415,40 @@ InputInfoList Driver::BuildJobsForActionNoCache(
     assert(CachedResults.find(ActionTC) != CachedResults.end() &&
            "Result does not exist??");
     Result = CachedResults[ActionTC].front();
+  } else if (auto *SA = dyn_cast<CIRSplitJobAction>(JA)) {
+    for (auto &UI : SA->getDependentActionsInfo()) {
+      assert(UI.DependentOffloadKind != Action::OFK_None &&
+             "CIR split with no offloading??");
+
+      std::string OffloadingPrefix = Action::GetOffloadingFileNamePrefix(
+          UI.DependentOffloadKind,
+          UI.DependentToolChain->getTriple().normalize(),
+          /*CreatePrefixForHost=*/true);
+      auto CurI = InputInfo(
+          SA,
+          GetNamedOutputPath(C, *SA, BaseInput, UI.DependentBoundArch,
+                             /*AtTopLevel=*/false,
+                             MultipleArchs ||
+                                 UI.DependentOffloadKind == Action::OFK_HIP,
+                             OffloadingPrefix),
+          BaseInput);
+      UnbundlingResults.push_back(CurI);
+
+      Action::OffloadKind CacheKind =
+          UI.DependentOffloadKind == Action::OFK_Host
+              ? Action::OFK_None
+              : UI.DependentOffloadKind;
+      CachedResults[{A, GetTriplePlusArchString(UI.DependentToolChain,
+                                                UI.DependentBoundArch,
+                                                CacheKind)}] = {
+          CurI};
+    }
+
+    std::pair<const Action *, std::string> ActionTC = {
+        A, GetTriplePlusArchString(TC, BoundArch, TargetDeviceOffloadKind)};
+    assert(CachedResults.find(ActionTC) != CachedResults.end() &&
+           "Result does not exist??");
+    Result = CachedResults[ActionTC].front();
   } else if (JA->getType() == types::TY_Nothing)
     Result = {InputInfo(A, BaseInput)};
   else {
@@ -6296,6 +6466,12 @@ InputInfoList Driver::BuildJobsForActionNoCache(
     if (T->canEmitIR())
       handleTimeTrace(C, Args, JA, BaseInput, Result);
   }
+
+  if (TargetDeviceOffloadKind != Action::OFK_None &&
+      TargetDeviceOffloadKind != Action::OFK_Host &&
+      JA->getOffloadingDeviceKind() == Action::OFK_None)
+    const_cast<JobAction *>(JA)->propagateDeviceOffloadInfo(
+        TargetDeviceOffloadKind, BoundArch.data(), TC);
 
   if (CCCPrintBindings && !CCGenDiagnostics) {
     llvm::errs() << "# \"" << T->getToolChain().getEffectiveTriple().str()

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4661,7 +4661,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
                 DeviceAction->propagateDeviceOffloadInfo(Kind, DepBoundArch,
                                                          DepTC);
 
-                // Wrap the assembled cubin into a CUDA. 
+                // Wrap the assembled cubin into a CUDA fatbinary.
                 if (Kind == Action::OFK_Cuda &&
                     isa<AssembleJobAction>(DeviceAction)) {
                   Action *Fatbin = buildCudaFatBinary(C, DeviceAction, DepTC,
@@ -5139,7 +5139,7 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
         ToolChains.push_back(TI->second);
 
       for (const ToolChain *TC : ToolChains) {
-        for (StringRef Arch : getOffloadArchs(C, C.getArgs(), Kind, *TC)) {
+        for (StringRef Arch : getOffloadArchs(C, Args, Kind, *TC)) {
           types::ID DeviceInputType =
               Kind == Action::OFK_HIP ? types::TY_HIP_DEVICE
                                       : types::TY_CUDA_DEVICE;

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5169,6 +5169,14 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
     if (MergeInputs.size() == 1)
       return HostAction;
 
+    // The host CIR compile sits below the split barrier, so host offload-kind
+    // propagation never reaches it. Stamp it directly so the host cc1 gets the
+    // CUDA setup (AddCudaIncludeArgs, -aux-triple) the stock host compile gets.
+    unsigned HostKinds = 0;
+    for (const CIROffloadDep &Dep : ArrayRef(Deps).drop_front())
+      HostKinds |= Dep.Kind;
+    HostAction->setHostOffloadInfo(HostKinds, /*OArch=*/nullptr);
+
     auto *Merge = C.MakeAction<CIRMergeJobAction>(MergeInputs);
     for (const CIROffloadDep &Dep : Deps)
       Merge->registerDependentActionInfo(Dep.TC, Dep.BoundArch, Dep.Kind);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3301,6 +3301,31 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
   }
 }
 
+// Wrap each device cubin and its ptx into per-target offload dependences and
+// link them into a single CUDA fatbinary.
+static Action *buildCudaFatBinary(Compilation &C,
+                                  ArrayRef<Action *> AssembleActions,
+                                  ArrayRef<const ToolChain *> ToolChains,
+                                  ArrayRef<const char *> BoundArchs) {
+  assert(AssembleActions.size() == ToolChains.size() &&
+         AssembleActions.size() == BoundArchs.size());
+  ActionList DeviceActions;
+  for (unsigned I = 0, E = AssembleActions.size(); I != E; ++I) {
+    Action *Assemble = AssembleActions[I];
+    assert(Assemble->getType() == types::TY_Object);
+    Action *Backend = Assemble->getInputs()[0];
+    assert(Backend->getType() == types::TY_PP_Asm);
+    for (Action *A : {Assemble, Backend}) {
+      OffloadAction::DeviceDependences DDep;
+      DDep.add(*A, *ToolChains[I], BoundArchs[I], Action::OFK_Cuda);
+      DeviceActions.push_back(C.MakeAction<OffloadAction>(DDep, A->getType()));
+    }
+  }
+  if (DeviceActions.empty())
+    return nullptr;
+  return C.MakeAction<LinkJobAction>(DeviceActions, types::TY_CUDA_FATBIN);
+}
+
 namespace {
 /// Provides a convenient interface for different programming models to generate
 /// the required device actions.
@@ -3658,7 +3683,9 @@ class OffloadingActionBuilder final {
       // fatbin.  The fatbin is then an input to the host action if not in
       // device-only mode.
       if (CompileDeviceOnly || CurPhase == phases::Backend) {
-        ActionList DeviceActions;
+        SmallVector<Action *, 4> AssembleActions;
+        SmallVector<const ToolChain *, 4> FatbinToolChains;
+        SmallVector<const char *, 4> FatbinArchs;
         for (unsigned I = 0, E = GpuArchList.size(); I != E; ++I) {
           // Produce the device action from the current phase up to the assemble
           // phase.
@@ -3685,25 +3712,15 @@ class OffloadingActionBuilder final {
               CompileDeviceOnly)
             continue;
 
-          Action *AssembleAction = CudaDeviceActions[I];
-          assert(AssembleAction->getType() == types::TY_Object);
-          assert(AssembleAction->getInputs().size() == 1);
-
-          Action *BackendAction = AssembleAction->getInputs()[0];
-          assert(BackendAction->getType() == types::TY_PP_Asm);
-
-          for (auto &A : {AssembleAction, BackendAction}) {
-            OffloadAction::DeviceDependences DDep;
-            DDep.add(*A, *ToolChains[I], GpuArchList[I], Action::OFK_Cuda);
-            DeviceActions.push_back(
-                C.MakeAction<OffloadAction>(DDep, A->getType()));
-          }
+          AssembleActions.push_back(CudaDeviceActions[I]);
+          FatbinToolChains.push_back(ToolChains[I]);
+          FatbinArchs.push_back(GpuArchList[I]);
         }
 
         // We generate the fat binary if we have device input actions.
-        if (!DeviceActions.empty()) {
-          CudaFatBinary =
-              C.MakeAction<LinkJobAction>(DeviceActions, types::TY_CUDA_FATBIN);
+        if (Action *FatBin = buildCudaFatBinary(C, AssembleActions,
+                                                FatbinToolChains, FatbinArchs)) {
+          CudaFatBinary = FatBin;
 
           if (!CompileDeviceOnly) {
             DA.add(*CudaFatBinary, *FatBinaryToolChain, /*BoundArch=*/nullptr,
@@ -4632,8 +4649,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       if (isCIROffloadMerge(C, Args) &&
           (Phase == phases::Backend || Phase == phases::Assemble))
         if (auto *OA = dyn_cast<OffloadAction>(Current)) {
-          Action *HostAction = OA->getHostDependence();
-          HostAction = ConstructPhaseAction(C, Args, Phase, HostAction);
+          
 
           OffloadAction::DeviceDependences DDeps;
           OA->doOnEachDeviceDependence(
@@ -4644,8 +4660,21 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
                     ConstructPhaseAction(C, Args, Phase, DepA, Kind);
                 DeviceAction->propagateDeviceOffloadInfo(Kind, DepBoundArch,
                                                          DepTC);
+
+                // Wrap the assembled cubin into a CUDA. 
+                if (Kind == Action::OFK_Cuda &&
+                    isa<AssembleJobAction>(DeviceAction)) {
+                  Action *Fatbin = buildCudaFatBinary(C, DeviceAction, DepTC,
+                                                      DepBoundArch);
+                  DDeps.add(*Fatbin, *DepTC, /*BoundArch=*/nullptr, Kind);
+                  return;
+                }
+
                 DDeps.add(*DeviceAction, *DepTC, DepBoundArch, Kind);
               });
+
+          Action *HostAction = OA->getHostDependence();
+          HostAction = ConstructPhaseAction(C, Args, Phase, HostAction);
 
           OffloadAction::HostDependence HDep(
               *HostAction, *C.getSingleOffloadToolChain<Action::OFK_Host>(),

--- a/clang/test/CIR/CodeGenCUDA/offload-merge-register.cu
+++ b/clang/test/CIR/CodeGenCUDA/offload-merge-register.cu
@@ -1,0 +1,28 @@
+// Verify that CUDA host LLVM IR resumed from the ClangIR offload-merge pipeline
+// emits the registration code for the device image and kernels.
+
+// REQUIRES: cir-support
+
+// RUN: %clang -target x86_64-unknown-linux-gnu -x cuda -fclangir \
+// RUN:   --cuda-gpu-arch=sm_80 \
+// RUN:   --cuda-path=%S/../../Driver/Inputs/CUDA_102/usr/local/cuda \
+// RUN:   -nocudainc -nocudalib -Wno-unknown-cuda-version \
+// RUN:   --clangir-offload-merge -S -emit-llvm %s -o - \
+// RUN: | FileCheck %s
+
+#include "Inputs/cuda.h"
+
+__global__ void kernel() {}
+
+// CHECK: @__cuda_fatbin_str = private constant
+// CHECK-SAME: section ".nv_fatbin"
+// CHECK: @__cuda_fatbin_wrapper = private constant
+// CHECK-SAME: section ".nvFatBinSegment"
+// CHECK: @__cuda_gpubin_handle = internal global ptr null
+// CHECK: @llvm.global_ctors = appending global
+// CHECK-SAME: @__cuda_module_ctor
+// CHECK: define internal void @__cuda_register_globals
+// CHECK: call{{.*}}@__cudaRegisterFunction
+// CHECK: define internal void @__cuda_module_ctor
+// CHECK: call{{.*}}@__cudaRegisterFatBinary
+// CHECK: call void @__cuda_register_globals

--- a/clang/test/Driver/cir-offload-merge.cu
+++ b/clang/test/Driver/cir-offload-merge.cu
@@ -26,8 +26,10 @@
 // MERGE: "-cc1"{{.*}} "-S"{{.*}} "-fcuda-is-device"{{.*}} "-o" "[[DEV_PTX:[^"]+\.s]]"{{.*}} "-x" "cir" "[[DEV_SPLIT]]"
 // PTX -> cubin.
 // MERGE: "{{.*}}ptxas{{(\.exe)?}}"{{.*}} "--output-file" "[[DEV_CUBIN:[^"]+\.o]]"{{.*}} "[[DEV_PTX]]"
-// Host module: CIR -> object, embedding the device binary.
-// MERGE: "-cc1"{{.*}} "-emit-obj"{{.*}} "-fcuda-include-gpubinary" "[[DEV_CUBIN]]"{{.*}} "-x" "cir" "[[HOST_SPLIT]]"
+// cubin -> CUDA fatbinary.
+// MERGE: "{{.*}}fatbinary{{(\.exe)?}}"{{.*}} "--create" "[[DEV_FATBIN:[^"]+\.fatbin]]"{{.*}} "--image3=kind=elf,sm=80,file=[[DEV_CUBIN]]"
+// Host module: CIR -> object, embedding the device fatbinary.
+// MERGE: "-cc1"{{.*}} "-emit-obj"{{.*}} "-fcuda-include-gpubinary" "[[DEV_FATBIN]]"{{.*}} "-x" "cir" "[[HOST_SPLIT]]"
 
 // Without --clangir-offload-merge the normal pipeline runs: no merge/split.
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \

--- a/clang/test/Driver/cir-offload-merge.cu
+++ b/clang/test/Driver/cir-offload-merge.cu
@@ -14,8 +14,11 @@
 // ptxas, and the resulting binary is embedded into the host object. The capture
 // variables track that every file is routed to the right consumer.
 
-// Host TU -> CIR.
-// MERGE: "-cc1"{{.*}} "-emit-cir"{{.*}} "-o" "[[HOST_CIR:[^"]+\.cir]]"
+// Host TU -> CIR. The host compile must carry the CUDA aux-triple (i.e. present
+// as a CUDA host compile) so it sees __global__, the runtime API, etc.; the
+// merge path used to drop this because the host action sits below the split
+// barrier and never received the host offload kind.
+// MERGE: "-cc1"{{.*}} "-aux-triple" "nvptx64-nvidia-cuda"{{.*}} "-emit-cir"{{.*}} "-o" "[[HOST_CIR:[^"]+\.cir]]"
 // Device TU -> CIR.
 // MERGE: "-cc1"{{.*}} "-emit-cir"{{.*}} "-fcuda-is-device"{{.*}} "-o" "[[DEV_CIR:[^"]+\.cir]]"
 // Both CIR modules are forwarded as inputs to -combine; output is the container.

--- a/clang/test/Driver/cir-offload-merge.cu
+++ b/clang/test/Driver/cir-offload-merge.cu
@@ -1,0 +1,37 @@
+// Driver pipeline for a CUDA compilation with ClangIR offload merge enabled
+// (single device arch).
+
+// REQUIRES: cir-support
+
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \
+// RUN:   --cuda-gpu-arch=sm_80 -nocudainc -nocudalib \
+// RUN:   --clangir-offload-merge -S -emit-llvm %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=MERGE
+
+// Host and device translation units are first lowered to serialized CIR, then
+// combined into one cir.offload.container and split back, and finally each
+// module resumes the backend from -x cir.
+// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-cir"
+// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-cir" {{.*}}"-fcuda-is-device"
+// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-combine" "-targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda-unknown-sm_80"
+// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-split" "-targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda-unknown-sm_80"
+// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-llvm-bc" {{.*}}"-fcuda-is-device" {{.*}}"-x" "cir"
+// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-llvm" {{.*}}"-fcuda-include-gpubinary" {{.*}}"-x" "cir"
+
+// Without --clangir-offload-merge the normal pipeline runs: no merge/split.
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \
+// RUN:   --cuda-gpu-arch=sm_80 -nocudainc -nocudalib -S -emit-llvm %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=NO-MERGE
+// NO-MERGE-NOT: "-combine"
+// NO-MERGE-NOT: "-split"
+// NO-MERGE-NOT: "-x" "cir"
+
+// -emit-cir stops at CIR; there is nothing to merge/split.
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \
+// RUN:   --cuda-gpu-arch=sm_80 -nocudainc -nocudalib --clangir-offload-merge \
+// RUN:   -emit-cir %s 2>&1 | FileCheck %s --check-prefix=EMIT-CIR
+// EMIT-CIR-NOT: "-combine"
+// EMIT-CIR-NOT: "-split"
+
+__global__ void kernel() {}
+void host() { kernel<<<1, 1>>>(); }

--- a/clang/test/Driver/cir-offload-merge.cu
+++ b/clang/test/Driver/cir-offload-merge.cu
@@ -1,26 +1,37 @@
 // Driver pipeline for a CUDA compilation with ClangIR offload merge enabled
-// (single device arch).
+// (single device arch), compiled all the way to an object.
 
 // REQUIRES: cir-support
 
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \
 // RUN:   --cuda-gpu-arch=sm_80 -nocudainc -nocudalib \
-// RUN:   --clangir-offload-merge -S -emit-llvm %s 2>&1 \
+// RUN:   --clangir-offload-merge -c %s 2>&1 \
 // RUN: | FileCheck %s --check-prefix=MERGE
 
 // Host and device translation units are first lowered to serialized CIR, then
-// combined into one cir.offload.container and split back, and finally each
-// module resumes the backend from -x cir.
-// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-cir"
-// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-cir" {{.*}}"-fcuda-is-device"
-// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-combine" "-targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda-unknown-sm_80"
-// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-split" "-targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda-unknown-sm_80"
-// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-llvm-bc" {{.*}}"-fcuda-is-device" {{.*}}"-x" "cir"
-// MERGE: "-cc1" {{.*}}"-fclangir" {{.*}}"-emit-llvm" {{.*}}"-fcuda-include-gpubinary" {{.*}}"-x" "cir"
+// combined into one cir.offload.container and split back. Each module resumes
+// the backend from -x cir: the device module is lowered to PTX, assembled by
+// ptxas, and the resulting binary is embedded into the host object. The capture
+// variables track that every file is routed to the right consumer.
+
+// Host TU -> CIR.
+// MERGE: "-cc1"{{.*}} "-emit-cir"{{.*}} "-o" "[[HOST_CIR:[^"]+\.cir]]"
+// Device TU -> CIR.
+// MERGE: "-cc1"{{.*}} "-emit-cir"{{.*}} "-fcuda-is-device"{{.*}} "-o" "[[DEV_CIR:[^"]+\.cir]]"
+// Both CIR modules are forwarded as inputs to -combine; output is the container.
+// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-combine" "-targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda-unknown-sm_80" "-output=[[CONTAINER:[^"]+\.cir]]" "-input=[[HOST_CIR]]" "-input=[[DEV_CIR]]"
+// The container is split back into one output per target.
+// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-split" "-targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda-unknown-sm_80" "-input=[[CONTAINER]]" "-output=[[HOST_SPLIT:[^"]+\.cir]]" "-output=[[DEV_SPLIT:[^"]+\.cir]]"
+// Device module: CIR -> PTX assembly.
+// MERGE: "-cc1"{{.*}} "-S"{{.*}} "-fcuda-is-device"{{.*}} "-o" "[[DEV_PTX:[^"]+\.s]]"{{.*}} "-x" "cir" "[[DEV_SPLIT]]"
+// PTX -> cubin.
+// MERGE: "{{.*}}ptxas{{(\.exe)?}}"{{.*}} "--output-file" "[[DEV_CUBIN:[^"]+\.o]]"{{.*}} "[[DEV_PTX]]"
+// Host module: CIR -> object, embedding the device binary.
+// MERGE: "-cc1"{{.*}} "-emit-obj"{{.*}} "-fcuda-include-gpubinary" "[[DEV_CUBIN]]"{{.*}} "-x" "cir" "[[HOST_SPLIT]]"
 
 // Without --clangir-offload-merge the normal pipeline runs: no merge/split.
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \
-// RUN:   --cuda-gpu-arch=sm_80 -nocudainc -nocudalib -S -emit-llvm %s 2>&1 \
+// RUN:   --cuda-gpu-arch=sm_80 -nocudainc -nocudalib -c %s 2>&1 \
 // RUN: | FileCheck %s --check-prefix=NO-MERGE
 // NO-MERGE-NOT: "-combine"
 // NO-MERGE-NOT: "-split"


### PR DESCRIPTION
We're back with the the PR's 😄

This is where the actions from https://github.com/RiverDave/llvm-project/pull/6 actually get placed into the driver's action graph - the construction that [#6](https://github.com/RiverDave/llvm-project/pull/6) deferred. With --clangir-offload-merge on a CUDA compile, each host/device TU is lowered to serialized CIR, combined into a single cir.offload.container, split back out, and every module then resumes the backend from -x cir (the .cir input path landed in https://github.com/RiverDave/llvm-project/pull/5).

The driver is a bit dense, so the relevants bits here are:

* BuildOffloadingActions builds the graph: host + per-arch device compiles become inputs to one CIRMergeJobAction, which feeds a single CIRSplitJobAction, wrapped in an OffloadAction that exposes the split as one host + N device dependences.
* ConstructPhaseAction stops the CUDA host/device compile at CIR (instead of going straight to LLVM) when the flag is set, so there's something for the merge to consume.
* BuildActions re-applies the backend phase to each split-out module separately - the host module and each device module have different toolchains/output types, so each needs its own backend action feeding off the shared split node.

I added an isCIROffloadMerge() helper since the same gating condition is checked across all three sites.

Here's a better illustration in case the above wasn't clear. (Thanks Claude 😉)
```mermaid
graph TD
  HSrc["InputAction<br/>foo.cu (host)"] --> HPre["PreprocessJobAction"]
  HPre --> HComp["CompileJobAction → TY_CIR<br/>-fclangir -emit-cir"]

  DSrc["InputAction<br/>foo.cu (cuda-device, sm_80)"] --> DPre["PreprocessJobAction"]
  DPre --> DComp["CompileJobAction → TY_CIR<br/>-fclangir -emit-cir -fcuda-is-device"]

  HComp --> Merge["CIRMergeJobAction → TY_CIR<br/>cir-offload-merge -combine"]
  DComp --> Merge

  Merge --> Split["CIRSplitJobAction → TY_CIR<br/>cir-offload-merge -split"]

  Split --> HBack["BackendJobAction host → TY_LLVM_IR<br/>-fclangir -emit-llvm -x cir"]
  Split --> DBack["BackendJobAction device → TY_LLVM_BC<br/>-fclangir -emit-llvm-bc -x cir"]

  HBack --> OA["OffloadAction (root)<br/>host + device grouping"]
  DBack --> OA
  
```