### PR TITLE
[CIR][CUDA] Add separate CUDA registration pass when consuming cir through CIRGenAction

### DIFF
--- a/clang/include/clang/CIR/CIRToCIRPasses.h
+++ b/clang/include/clang/CIR/CIRToCIRPasses.h
@@ -14,12 +14,17 @@
 #define CLANG_CIR_CIRTOCIRPASSES_H
 
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 
 #include <memory>
 
 namespace clang {
 class ASTContext;
 }
+
+namespace llvm::vfs {
+class FileSystem;
+} // namespace llvm::vfs
 
 namespace mlir {
 class MLIRContext;
@@ -28,11 +33,18 @@ class ModuleOp;
 
 namespace cir {
 
-// Run set of cleanup/prepare/etc passes CIR <-> CIR.
+class LowerModule;
+
+// Run set of cleanup/prepare/etc passes CIR <-> CIR. The caller owns
+// `lowerModule`, which provides the target/LangOpts state for AST-free
+// passes (LoweringPrepare and any future helpers). `astCtx` is still
+// required by IdiomRecognizer and the AST-fact materialization pass.
 mlir::LogicalResult
 runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirCtx,
-                  clang::ASTContext &astCtx, bool enableVerifier,
-                  bool enableIdiomRecognizer, bool enableCIRSimplify);
+                  clang::ASTContext &astCtx, cir::LowerModule &lowerModule,
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+                  bool enableVerifier, bool enableIdiomRecognizer,
+                  bool enableCIRSimplify);
 
 } // namespace cir
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRAttrs.td
@@ -1661,6 +1661,52 @@ def CIR_ASTVarDeclAttr : CIR_AST<"VarDecl", "var.decl", [
 ]>;
 
 //===----------------------------------------------------------------------===//
+// StaticLocalInfoAttr
+//===----------------------------------------------------------------------===//
+
+def CIR_StaticLocalInfoAttr
+    : CIR_Attr<"StaticLocalInfo", "static_local_info",
+               [ASTVarDeclInterface]> {
+  let summary = "AST-free cache of static-local VarDecl facts.";
+  let description = [{
+    Materialized form of the facts `cir::ASTVarDeclInterface` exposes, so
+    that post-CIRGen passes (notably LoweringPrepare) can query them without
+    a live `clang::ASTContext`. Produced by the `cir-materialize-ast-facts`
+    pass from an AST-backed `ASTVarDeclAttr`.
+
+    The TLS and template-specialization kinds are encoded as plain integers
+    matching the underlying `clang::VarDecl::TLSKind` and
+    `clang::TemplateSpecializationKind` enumerators.
+  }];
+
+  let parameters = (ins
+    "bool":$is_local_var_decl,
+    "uint32_t":$tls,
+    "bool":$is_inline,
+    "uint32_t":$tsk
+  );
+
+  let assemblyFormat = [{
+    `<` struct($is_local_var_decl, $tls, $is_inline, $tsk) `>`
+  }];
+
+  let extraClassDeclaration = [{
+    // Satisfy ASTVarDeclInterface by reading cached fields instead of an
+    // AST-backed VarDecl pointer.
+    bool isLocalVarDecl() const { return getIsLocalVarDecl(); }
+    clang::VarDecl::TLSKind getTLSKind() const {
+      return static_cast<clang::VarDecl::TLSKind>(getTls());
+    }
+    bool isInline() const { return getIsInline(); }
+    clang::TemplateSpecializationKind getTemplateSpecializationKind() const {
+      return static_cast<clang::TemplateSpecializationKind>(getTsk());
+    }
+  }];
+
+  let canHaveIllegalCXXABIType = 0;
+}
+
+//===----------------------------------------------------------------------===//
 // AnnotationAttr
 //===----------------------------------------------------------------------===//
 

--- a/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIRDialect.td
@@ -79,6 +79,9 @@ def CIR_Dialect : Dialect {
     static llvm::StringRef getArgAttrsAttrName() { return "arg_attrs"; }
     static llvm::StringRef getRecordLayoutsAttrName() { return "cir.record_layouts"; }
     static llvm::StringRef getCUDABinaryHandleAttrName() { return "cir.cu.binary_handle"; }
+    // Mangled symbol name of the C++20 named-module initializer function,
+    // precomputed by CIRGen so later passes don't need a live ASTContext.
+    static llvm::StringRef getCXXModuleInitFnNameAttrName() { return "cir.cxx_module_init_fn_name"; }
     static llvm::StringRef getMustTailAttrName() { return "musttail"; }
     static llvm::StringRef getCatchCopyThunkAttrName() { return "cir.eh.catch_copy_thunk"; }
 

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -42,6 +42,10 @@ std::unique_ptr<Pass> createLoweringPreparePass();
 std::unique_ptr<Pass> createLoweringPreparePass(
     cir::LowerModule *lowerModule,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr);
+std::unique_ptr<Pass> createCUDARegisterModulePass();
+std::unique_ptr<Pass> createCUDARegisterModulePass(
+    cir::LowerModule *lowerModule,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr);
 std::unique_ptr<Pass> createMaterializeASTFactsPass();
 std::unique_ptr<Pass> createGotoSolverPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass();

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -31,6 +31,7 @@ std::unique_ptr<Pass> createCallConvLoweringPass();
 std::unique_ptr<Pass> createHoistAllocasPass();
 std::unique_ptr<Pass> createLoweringPreparePass();
 std::unique_ptr<Pass> createLoweringPreparePass(clang::ASTContext *astCtx);
+std::unique_ptr<Pass> createMaterializeASTFactsPass();
 std::unique_ptr<Pass> createGotoSolverPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass(clang::ASTContext *astCtx);

--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -14,10 +14,19 @@
 #define CLANG_CIR_DIALECT_PASSES_H
 
 #include "mlir/Pass/Pass.h"
+#include "llvm/ADT/IntrusiveRefCntPtr.h"
 
 namespace clang {
 class ASTContext;
 }
+
+namespace llvm::vfs {
+class FileSystem;
+} // namespace llvm::vfs
+
+namespace cir {
+class LowerModule;
+} // namespace cir
 
 namespace mlir {
 
@@ -30,7 +39,9 @@ std::unique_ptr<Pass> createTargetLoweringPass();
 std::unique_ptr<Pass> createCallConvLoweringPass();
 std::unique_ptr<Pass> createHoistAllocasPass();
 std::unique_ptr<Pass> createLoweringPreparePass();
-std::unique_ptr<Pass> createLoweringPreparePass(clang::ASTContext *astCtx);
+std::unique_ptr<Pass> createLoweringPreparePass(
+    cir::LowerModule *lowerModule,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr);
 std::unique_ptr<Pass> createMaterializeASTFactsPass();
 std::unique_ptr<Pass> createGotoSolverPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass();

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -184,6 +184,24 @@ def LoweringPrepare : Pass<"cir-lowering-prepare"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def MaterializeASTFacts : Pass<"cir-materialize-ast-facts", "mlir::ModuleOp"> {
+  let summary = "Cache AST-derived facts as CIR attributes";
+  let description = [{
+    Walks the module and, for any `cir.global` whose `ast` attribute is an
+    AST-backed `ASTVarDeclAttr`, replaces it with a `StaticLocalInfoAttr`
+    that carries the same facts (isLocalVarDecl, TLSKind, isInline,
+    TemplateSpecializationKind) as plain fields. After this pass runs,
+    downstream passes such as `cir-lowering-prepare` can query the
+    `ASTVarDeclInterface` without a live `clang::ASTContext`.
+
+    Intended to run while the AST is still reachable, i.e. immediately after
+    CIRGen and before any step that may serialize CIR for later consumption
+    by a separate tool invocation.
+  }];
+  let constructor = "mlir::createMaterializeASTFactsPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
+
 def IdiomRecognizer : Pass<"cir-idiom-recognizer", "mlir::ModuleOp"> {
   let summary = "Raise calls to C/C++ libraries to CIR operations";
   let description = [{

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -184,6 +184,17 @@ def LoweringPrepare : Pass<"cir-lowering-prepare"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def CUDARegisterModule : Pass<"cir-cuda-register-module", "mlir::ModuleOp"> {
+  let summary = "Build CUDA module registration runtime calls";
+  let description = [{
+    This pass emits the CUDA/HIP module constructor, destructor, fatbin globals,
+    and kernel/device variable registration calls from serialized CIR CUDA
+    registration attributes.
+  }];
+  let constructor = "mlir::createCUDARegisterModulePass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
+
 def MaterializeASTFacts : Pass<"cir-materialize-ast-facts", "mlir::ModuleOp"> {
   let summary = "Cache AST-derived facts as CIR attributes";
   let description = [{

--- a/clang/include/clang/CIR/MissingFeatures.h
+++ b/clang/include/clang/CIR/MissingFeatures.h
@@ -159,8 +159,6 @@ struct MissingFeatures {
   static bool globalCtorAssociatedData() { return false; }
 
   // LowerModule handling
-  static bool lowerModuleCodeGenOpts() { return false; }
-  static bool lowerModuleLangOpts() { return false; }
   static bool targetLoweringInfo() { return false; }
 
   // Extra checks for lowerGetMethod in ItaniumCXXABI

--- a/clang/lib/CIR/CodeGen/CIRGenModule.cpp
+++ b/clang/lib/CIR/CodeGen/CIRGenModule.cpp
@@ -27,6 +27,7 @@
 #include "clang/AST/RecordLayout.h"
 #include "clang/AST/StmtOpenMP.h"
 #include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/Basic/Module.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
@@ -3565,6 +3566,24 @@ void CIRGenModule::release() {
     getCUDARuntime().finalizeModule();
 
   emitLLVMUsed();
+
+  // Precompute the mangled C++20 named-module initializer function name and
+  // stash it on the ModuleOp so LoweringPrepare (which may run without a live
+  // ASTContext in split-compilation flows) can read it back as an attribute.
+  if (langOpts.CPlusPlusModules &&
+      getCXXABI().getMangleContext().getKind() ==
+          clang::ItaniumMangleContext::MK_Itanium) {
+    if (clang::Module *primary = astContext.getCurrentNamedModule();
+        primary && !primary->isModuleImplementation()) {
+      llvm::SmallString<256> fnName;
+      llvm::raw_svector_ostream out(fnName);
+      cast<clang::ItaniumMangleContext>(getCXXABI().getMangleContext())
+          .mangleModuleInitializer(primary, out);
+      theModule->setAttr(
+          cir::CIRDialect::getCXXModuleInitFnNameAttrName(),
+          builder.getStringAttr(fnName));
+    }
+  }
 
   // Classic codegen calls `checkAliases` here to validate any alias
   // definitions emitted during codegen.

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -13,6 +13,7 @@ add_clang_library(MLIRCIRTransforms
   LoweringPrepare.cpp
   GotoSolver.cpp
   IdiomRecognizer.cpp
+  MaterializeASTFacts.cpp
 
   DEPENDS
   MLIRCIRPassIncGen

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -7,16 +7,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "PassDetail.h"
+#include "TargetLowering/LowerModule.h"
 #include "mlir/IR/Attributes.h"
 #include "mlir/IR/BuiltinAttributeInterfaces.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/Location.h"
 #include "mlir/IR/Value.h"
-#include "clang/AST/ASTContext.h"
-#include "clang/AST/Mangle.h"
 #include "clang/Basic/Cuda.h"
-#include "clang/Basic/Module.h"
-#include "clang/Basic/SourceManager.h"
 #include "clang/Basic/Specifiers.h"
 #include "clang/Basic/TargetCXXABI.h"
 #include "clang/Basic/TargetInfo.h"
@@ -231,7 +228,8 @@ struct LoweringPreparePass
     } else if (useARMGuardVarABI()) {
       // Guard variables are size width on ARM (32-bit AArch32, 64-bit AArch64).
       const unsigned sizeTypeSize =
-          astCtx->getTypeSize(astCtx->getSignedSizeType());
+          lowerModule->getTarget().getTypeWidth(
+              lowerModule->getTarget().getSignedSizeType());
       guardTy =
           cir::IntType::get(&getContext(), sizeTypeSize, /*isSigned=*/true);
       guardAlignment =
@@ -259,7 +257,7 @@ struct LoweringPreparePass
       // for non-ELF and non-Wasm object formats, so only do it for ELF and
       // Wasm.
       bool hasComdat = globalOp.getComdat();
-      const llvm::Triple &triple = astCtx->getTargetInfo().getTriple();
+      const llvm::Triple &triple = lowerModule->getTarget().getTriple();
       // TODO(cir): for now, we're just setting comdat to true, but it should
       // contain a comdat reference name here instead.
       if (!isLocalVarDecl && hasComdat &&
@@ -276,10 +274,19 @@ struct LoweringPreparePass
   }
 
   ///
-  /// AST related
-  /// -----------
+  /// Target / language fact source
+  /// -----------------------------
 
-  clang::ASTContext *astCtx;
+  /// Target/LangOpts/CXXABI bundle the pass reads instead of going to a live
+  /// ASTContext.  Set from the surrounding cc1 invocation by
+  /// runCIRToCIRPasses (or by the .cir input path in CIRGenAction).  Always
+  /// non-null while the pass runs.
+  cir::LowerModule *lowerModule = nullptr;
+
+  /// Filesystem used to read CUDA/HIP fatbin payloads referenced by the
+  /// module.  Defaults to the real filesystem; CIRGen can plumb the cc1
+  /// invocation's VFS instead so virtualized inputs keep working.
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs;
 
   /// Tracks current module.
   mlir::ModuleOp mlirModule;
@@ -324,7 +331,7 @@ struct LoweringPreparePass
   /// Returns true if the target uses ARM-style guard variables for static
   /// local initialization (32-bit guard, check bit 0 only).
   bool useARMGuardVarABI() const {
-    switch (astCtx->getCXXABIKind()) {
+    switch (lowerModule->getCXXABIKind()) {
     case clang::TargetCXXABI::GenericARM:
     case clang::TargetCXXABI::iOS:
     case clang::TargetCXXABI::WatchOS:
@@ -364,7 +371,7 @@ struct LoweringPreparePass
 
     llvm::StringLiteral nameAtExit = "__cxa_atexit";
     if (tls)
-      nameAtExit = astCtx->getTargetInfo().getTriple().isOSDarwin()
+      nameAtExit = lowerModule->getTarget().getTriple().isOSDarwin()
                        ? llvm::StringLiteral("_tlv_atexit")
                        : llvm::StringLiteral("__cxa_thread_atexit");
 
@@ -500,7 +507,10 @@ struct LoweringPreparePass
     builder.createYield(loc); // Outermost IfOp
   }
 
-  void setASTContext(clang::ASTContext *c) { astCtx = c; }
+  void setLowerModule(cir::LowerModule *lm) { lowerModule = lm; }
+  void setVFS(llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> v) {
+    vfs = std::move(v);
+  }
 };
 
 } // namespace
@@ -792,7 +802,7 @@ buildRangeReductionComplexDiv(CIRBaseBuilderTy &builder, mlir::Location loc,
 }
 
 static mlir::Type higherPrecisionElementTypeForComplexArithmetic(
-    mlir::MLIRContext &context, clang::ASTContext &cc,
+    mlir::MLIRContext &context, const cir::LowerModule &lm,
     CIRBaseBuilderTy &builder, mlir::Type elementType) {
 
   auto getHigherPrecisionFPType = [&context](mlir::Type type) -> mlir::Type {
@@ -809,8 +819,9 @@ static mlir::Type higherPrecisionElementTypeForComplexArithmetic(
   };
 
   auto getFloatTypeSemantics =
-      [&cc](mlir::Type type) -> const llvm::fltSemantics & {
-    const clang::TargetInfo &info = cc.getTargetInfo();
+      [&lm](mlir::Type type) -> const llvm::fltSemantics & {
+    const clang::TargetInfo &info = lm.getTarget();
+    const clang::LangOptions &langOpts = lm.getLangOpts();
     if (mlir::isa<cir::FP16Type>(type))
       return info.getHalfFormat();
 
@@ -824,13 +835,13 @@ static mlir::Type higherPrecisionElementTypeForComplexArithmetic(
       return info.getDoubleFormat();
 
     if (mlir::isa<cir::LongDoubleType>(type)) {
-      if (cc.getLangOpts().OpenMP && cc.getLangOpts().OpenMPIsTargetDevice)
+      if (langOpts.OpenMP && langOpts.OpenMPIsTargetDevice)
         llvm_unreachable("NYI Float type semantics with OpenMP");
       return info.getLongDoubleFormat();
     }
 
     if (mlir::isa<cir::FP128Type>(type)) {
-      if (cc.getLangOpts().OpenMP && cc.getLangOpts().OpenMPIsTargetDevice)
+      if (langOpts.OpenMP && langOpts.OpenMPIsTargetDevice)
         llvm_unreachable("NYI Float type semantics with OpenMP");
       return info.getFloat128Format();
     }
@@ -865,7 +876,7 @@ static mlir::Value
 lowerComplexDiv(LoweringPreparePass &pass, CIRBaseBuilderTy &builder,
                 mlir::Location loc, cir::ComplexDivOp op, mlir::Value lhsReal,
                 mlir::Value lhsImag, mlir::Value rhsReal, mlir::Value rhsImag,
-                mlir::MLIRContext &mlirCx, clang::ASTContext &cc) {
+                mlir::MLIRContext &mlirCx, const cir::LowerModule &lm) {
   cir::ComplexType complexTy = op.getType();
   if (mlir::isa<cir::FPTypeInterface>(complexTy.getElementType())) {
     cir::ComplexRangeKind range = op.getRange();
@@ -881,7 +892,7 @@ lowerComplexDiv(LoweringPreparePass &pass, CIRBaseBuilderTy &builder,
     if (range == cir::ComplexRangeKind::Promoted) {
       mlir::Type originalElementType = complexTy.getElementType();
       mlir::Type higherPrecisionElementType =
-          higherPrecisionElementTypeForComplexArithmetic(mlirCx, cc, builder,
+          higherPrecisionElementTypeForComplexArithmetic(mlirCx, lm, builder,
                                                          originalElementType);
 
       if (!higherPrecisionElementType)
@@ -929,7 +940,7 @@ void LoweringPreparePass::lowerComplexDivOp(cir::ComplexDivOp op) {
 
   mlir::Value loweredResult =
       lowerComplexDiv(*this, builder, loc, op, lhsReal, lhsImag, rhsReal,
-                      rhsImag, getContext(), *astCtx);
+                      rhsImag, getContext(), *lowerModule);
   op.replaceAllUsesWith(loweredResult);
   op.erase();
 }
@@ -1318,7 +1329,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // We only need to use thread-safe statics for local non-TLS variables and
   // inline variables; other global initialization is always single-threaded
   // or (through lazy dynamic loading in multiple threads) unsequenced.
-  bool threadsafe = astCtx->getLangOpts().ThreadsafeStatics &&
+  bool threadsafe = lowerModule->getLangOpts().ThreadsafeStatics &&
                     (varDecl.isLocalVarDecl() || nonTemplateInline) &&
                     !varDecl.getTLSKind();
 
@@ -1359,7 +1370,7 @@ void LoweringPreparePass::handleStaticLocal(cir::GlobalOp globalOp,
   // call __cxa_guard_acquire unconditionally. The "inline" check isn't
   // actually inline, and the user might not expect calls to __atomic libcalls.
   unsigned maxInlineWidthInBits =
-      astCtx->getTargetInfo().getMaxAtomicInlineWidth();
+      lowerModule->getTarget().getMaxAtomicInlineWidth();
 
   if (!threadsafe || maxInlineWidthInBits) {
     // Load the first byte of the guard variable.
@@ -1450,17 +1461,17 @@ void LoweringPreparePass::lowerLocalInitOp(cir::LocalInitOp initOp) {
   initOp.erase();
 }
 static bool isThreadWrapperReplaceable(cir::TLS_Model tls,
-                                       clang::ASTContext &astCtx) {
+                                       const cir::LowerModule &lm) {
   return tls == cir::TLS_Model::GeneralDynamic &&
-         astCtx.getTargetInfo().getTriple().isOSDarwin();
+         lm.getTarget().getTriple().isOSDarwin();
 }
 
 static cir::GlobalLinkageKind
-getThreadLocalWrapperLinkage(GlobalOp op, clang::ASTContext &astCtx) {
+getThreadLocalWrapperLinkage(GlobalOp op, const cir::LowerModule &lm) {
   if (isLocalLinkage(op.getLinkage()))
     return op.getLinkage();
 
-  if (isThreadWrapperReplaceable(*op.getTlsModel(), astCtx))
+  if (isThreadWrapperReplaceable(*op.getTlsModel(), lm))
     if (!isLinkOnceLinkage(op.getLinkage()) &&
         !isWeakODRLinkage(op.getLinkage()))
       return op.getLinkage();
@@ -1490,13 +1501,13 @@ LoweringPreparePass::getOrCreateThreadLocalWrapper(CIRBaseBuilderTy &builder,
       cir::FuncOp::create(builder, op.getLoc(), wrapperName, funcType);
 
   cir::GlobalLinkageKind linkageKind =
-      getThreadLocalWrapperLinkage(op, *astCtx);
+      getThreadLocalWrapperLinkage(op, *lowerModule);
   func.setLinkageAttr(
       cir::GlobalLinkageKindAttr::get(&getContext(), linkageKind));
 
   // TODO(cir): This is supposed to refer to the comdat of the global symbol,
   // but that isn't in CIR yet.
-  if (astCtx->getTargetInfo().getTriple().supportsCOMDAT() &&
+  if (lowerModule->getTarget().getTriple().supportsCOMDAT() &&
       func.isWeakForLinker())
     func.setComdat(true);
 
@@ -1504,12 +1515,12 @@ LoweringPreparePass::getOrCreateThreadLocalWrapper(CIRBaseBuilderTy &builder,
       func, mlir::SymbolTable::Visibility::Private);
 
   if (!isLocalLinkage(linkageKind)) {
-    if (!isThreadWrapperReplaceable(*op.getTlsModel(), *astCtx) ||
+    if (!isThreadWrapperReplaceable(*op.getTlsModel(), *lowerModule) ||
         isLinkOnceLinkage(linkageKind) || isWeakODRLinkage(linkageKind) ||
         op.getGlobalVisibility() == cir::VisibilityKind::Hidden)
       func.setGlobalVisibility(cir::VisibilityKind::Hidden);
   }
-  if (isThreadWrapperReplaceable(*op.getTlsModel(), *astCtx))
+  if (isThreadWrapperReplaceable(*op.getTlsModel(), *lowerModule))
     op->emitError("Unhandled thread wrapper attributes for CC and Nounwind");
 
   threadLocalWrappers.insert({wrapperName.getValue(), func});
@@ -1857,18 +1868,11 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
   // way as a non-modular TU with imports.
   // The C++20 named-module init function name is precomputed by CIRGen and
   // stored as a module-level attribute, so this pass does not need a live
-  // ASTContext in split-compilation flows. Fall back to the AST-based path
-  // only when the attribute is absent (e.g. tests that bypass CIRGen).
+  // ASTContext.  Modules built directly from textual CIR can opt in to the
+  // module-init form by setting the same attribute.
   if (auto fnNameAttr = mlirModule->getAttrOfType<mlir::StringAttr>(
           cir::CIRDialect::getCXXModuleInitFnNameAttrName())) {
     fnName += fnNameAttr.getValue();
-  } else if (astCtx && astCtx->getCurrentNamedModule() &&
-             !astCtx->getCurrentNamedModule()->isModuleImplementation()) {
-    llvm::raw_svector_ostream out(fnName);
-    std::unique_ptr<clang::MangleContext> mangleCtx(
-        astCtx->createMangleContext());
-    cast<clang::ItaniumMangleContext>(*mangleCtx)
-        .mangleModuleInitializer(astCtx->getCurrentNamedModule(), out);
     linkage = cir::GlobalLinkageKind::ExternalLinkage;
   } else {
     fnName += "_GLOBAL__sub_I_";
@@ -1897,7 +1901,7 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
 /// region is non-empty, the ctor loop is wrapped in a cir.cleanup.scope whose
 /// EH cleanup performs a reverse destruction loop using the partial dtor body.
 static void lowerArrayDtorCtorIntoLoop(cir::CIRBaseBuilderTy &builder,
-                                       clang::ASTContext *astCtx,
+                                       const cir::LowerModule *lm,
                                        mlir::Operation *op, mlir::Type eltTy,
                                        mlir::Value addr,
                                        mlir::Value numElements,
@@ -1905,10 +1909,10 @@ static void lowerArrayDtorCtorIntoLoop(cir::CIRBaseBuilderTy &builder,
   mlir::Location loc = op->getLoc();
   bool isDynamic = numElements != nullptr;
 
-  // TODO: instead of getting the size from the AST context, create alias for
+  // TODO: instead of getting the size from the lower module, create alias for
   // PtrDiffTy and unify with CIRGen stuff.
   const unsigned sizeTypeSize =
-      astCtx->getTypeSize(astCtx->getSignedSizeType());
+      lm->getTarget().getTypeWidth(lm->getTarget().getSignedSizeType());
 
   // Both constructors and destructors use end = begin + numElements.
   // Constructors iterate forward [begin, end).  Destructors iterate backward
@@ -2075,7 +2079,7 @@ void LoweringPreparePass::lowerArrayDtor(cir::ArrayDtor op) {
   mlir::Type eltTy = op->getRegion(0).getArgument(0).getType();
 
   if (op.getNumElements()) {
-    lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+    lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                                op.getNumElements(), /*arrayLen=*/0,
                                /*isCtor=*/false);
     return;
@@ -2083,7 +2087,7 @@ void LoweringPreparePass::lowerArrayDtor(cir::ArrayDtor op) {
 
   auto arrayLen =
       mlir::cast<cir::ArrayType>(op.getAddr().getType().getPointee()).getSize();
-  lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+  lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                              /*numElements=*/nullptr, arrayLen,
                              /*isCtor=*/false);
 }
@@ -2095,7 +2099,7 @@ void LoweringPreparePass::lowerArrayCtor(cir::ArrayCtor op) {
   mlir::Type eltTy = op->getRegion(0).getArgument(0).getType();
 
   if (op.getNumElements()) {
-    lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+    lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                                op.getNumElements(), /*arrayLen=*/0,
                                /*isCtor=*/true);
     return;
@@ -2103,7 +2107,7 @@ void LoweringPreparePass::lowerArrayCtor(cir::ArrayCtor op) {
 
   auto arrayLen =
       mlir::cast<cir::ArrayType>(op.getAddr().getType().getPointee()).getSize();
-  lowerArrayDtorCtorIntoLoop(builder, astCtx, op, eltTy, op.getAddr(),
+  lowerArrayDtorCtorIntoLoop(builder, lowerModule, op, eltTy, op.getAddr(),
                              /*numElements=*/nullptr, arrayLen,
                              /*isCtor=*/true);
 }
@@ -2299,8 +2303,8 @@ void LoweringPreparePass::runOnOp(mlir::Operation *op) {
   }
 }
 
-static llvm::StringRef getCUDAPrefix(clang::ASTContext *astCtx) {
-  if (astCtx->getLangOpts().HIP)
+static llvm::StringRef getCUDAPrefix(const cir::LowerModule *lm) {
+  if (lm->getLangOpts().HIP)
     return "hip";
   return "cuda";
 }
@@ -2330,9 +2334,9 @@ static std::string addUnderscoredPrefix(llvm::StringRef prefix,
 /// }
 /// \endcode
 void LoweringPreparePass::buildCUDAModuleCtor() {
-  bool isHIP = astCtx->getLangOpts().HIP;
+  bool isHIP = lowerModule->getLangOpts().HIP;
 
-  if (astCtx->getLangOpts().GPURelocatableDeviceCode)
+  if (lowerModule->getLangOpts().GPURelocatableDeviceCode)
     llvm_unreachable("GPU RDC NYI");
 
   // For CUDA without -fgpu-rdc, it's safe to stop generating ctor
@@ -2355,10 +2359,10 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
           .getName()
           .getValue();
 
-  llvm::vfs::FileSystem &vfs =
-      astCtx->getSourceManager().getFileManager().getVirtualFileSystem();
+  llvm::vfs::FileSystem &gpuBinaryVFS =
+      vfs ? *vfs : *llvm::vfs::getRealFileSystem();
   llvm::ErrorOr<std::unique_ptr<llvm::MemoryBuffer>> gpuBinaryOrErr =
-      vfs.getBufferForFile(cudaGPUBinaryName);
+      gpuBinaryVFS.getBufferForFile(cudaGPUBinaryName);
   if (std::error_code ec = gpuBinaryOrErr.getError()) {
     mlirModule->emitError("cannot open GPU binary file: " + cudaGPUBinaryName +
                           ": " + ec.message());
@@ -2368,7 +2372,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
       std::move(gpuBinaryOrErr.get());
 
   // Set up common types and builder.
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
   mlir::Location loc = mlirModule->getLoc();
   CIRBaseBuilderTy builder(getContext());
   builder.setInsertionPointToStart(mlirModule.getBody());
@@ -2377,17 +2381,17 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   PointerType voidPtrTy = builder.getVoidPtrTy();
   PointerType voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
   IntType intTy = builder.getSIntNTy(32);
-  IntType charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
+  IntType charTy = cir::IntType::get(&getContext(), lowerModule->getTarget().getCharWidth(),
                                      /*isSigned=*/false);
 
   // --- Create fatbin globals ---
 
   // The section names are different for MAC OS X.
   llvm::StringRef fatbinConstName =
-      astCtx->getLangOpts().HIP ? ".hip_fatbin" : ".nv_fatbin";
+      lowerModule->getLangOpts().HIP ? ".hip_fatbin" : ".nv_fatbin";
 
   llvm::StringRef fatbinSectionName =
-      astCtx->getLangOpts().HIP ? ".hipFatBinSegment" : ".nvFatBinSegment";
+      lowerModule->getLangOpts().HIP ? ".hipFatBinSegment" : ".nvFatBinSegment";
 
   // Create the fatbin string constant with GPU binary contents.
   auto fatbinType =
@@ -2518,7 +2522,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
     }
     return;
   }
-  if (!astCtx->getLangOpts().GPURelocatableDeviceCode) {
+  if (!lowerModule->getLangOpts().GPURelocatableDeviceCode) {
 
     // --- Create CUDA CTOR-DTOR ---
     // Register binary with CUDA runtime. This is substantially different in
@@ -2543,7 +2547,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
     //      void __cudaRegisterFatBinaryEnd(void **fatbinHandle);
     // This is CUDA-specific, so no need to use `addUnderscoredPrefix`.
     if (clang::CudaFeatureEnabled(
-            astCtx->getTargetInfo().getSDKVersion(),
+            lowerModule->getTarget().getSDKVersion(),
             clang::CudaFeature::CUDA_USES_FATBIN_REGISTER_END)) {
       cir::CIRBaseBuilderTy globalBuilder(getContext());
       globalBuilder.setInsertionPointToStart(mlirModule.getBody());
@@ -2578,7 +2582,7 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDAModuleDtor() {
   if (!mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName()))
     return {};
 
-  llvm::StringRef prefix = getCUDAPrefix(astCtx);
+  llvm::StringRef prefix = getCUDAPrefix(lowerModule);
 
   VoidType voidTy = VoidType::get(&getContext());
   PointerType voidPtrPtrTy = PointerType::get(PointerType::get(voidTy));
@@ -2635,7 +2639,7 @@ std::optional<FuncOp> LoweringPreparePass::buildHIPModuleDtor() {
   if (!mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName()))
     return {};
 
-  llvm::StringRef prefix = getCUDAPrefix(astCtx);
+  llvm::StringRef prefix = getCUDAPrefix(lowerModule);
 
   VoidType voidTy = VoidType::get(&getContext());
   PointerType voidPtrPtrTy = PointerType::get(PointerType::get(voidTy));
@@ -2698,7 +2702,7 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDARegisterGlobals() {
   builder.setInsertionPointToStart(mlirModule.getBody());
 
   mlir::Location loc = mlirModule.getLoc();
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
 
   auto voidTy = VoidType::get(&getContext());
   auto voidPtrTy = PointerType::get(voidTy);
@@ -2724,14 +2728,14 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDARegisterGlobals() {
 void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
     cir::CIRBaseBuilderTy &builder, FuncOp regGlobalFunc) {
   mlir::Location loc = mlirModule.getLoc();
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
   cir::CIRDataLayout dataLayout(mlirModule);
 
   auto voidTy = VoidType::get(&getContext());
   auto voidPtrTy = PointerType::get(voidTy);
   auto voidPtrPtrTy = PointerType::get(voidPtrTy);
   IntType intTy = builder.getSIntNTy(32);
-  IntType charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
+  IntType charTy = cir::IntType::get(&getContext(), lowerModule->getTarget().getCharWidth(),
                                      /*isSigned=*/false);
 
   // Extract the GPU binary handle argument.
@@ -2773,7 +2777,7 @@ void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
   };
 
   cir::ConstantOp cirNullPtr = builder.getNullPtr(voidPtrTy, loc);
-  bool isHIP = astCtx->getLangOpts().HIP;
+  bool isHIP = lowerModule->getLangOpts().HIP;
   for (auto kernelName : cudaKernelMap.keys()) {
     FuncOp deviceStub = cudaKernelMap[kernelName];
     GlobalOp deviceFuncStr = makeConstantString(kernelName);
@@ -2811,15 +2815,15 @@ void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
 void LoweringPreparePass::buildCUDARegisterVars(cir::CIRBaseBuilderTy &builder,
                                                 FuncOp regGlobalFunc) {
   mlir::Location loc = mlirModule.getLoc();
-  llvm::StringRef cudaPrefix = getCUDAPrefix(astCtx);
+  llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
   cir::CIRDataLayout dataLayout(mlirModule);
 
   PointerType voidPtrTy = builder.getVoidPtrTy();
   PointerType voidPtrPtrTy = builder.getPointerTo(voidPtrTy);
   IntType intTy = builder.getSIntNTy(32);
   IntType sizeTy =
-      builder.getUIntNTy(astCtx->getTargetInfo().getMaxPointerWidth());
-  IntType charTy = cir::IntType::get(&getContext(), astCtx->getCharWidth(),
+      builder.getUIntNTy(lowerModule->getTarget().getMaxPointerWidth());
+  IntType charTy = cir::IntType::get(&getContext(), lowerModule->getTarget().getCharWidth(),
                                      /*isSigned=*/false);
 
   if (cudaDeviceVars.empty())
@@ -2908,7 +2912,7 @@ void LoweringPreparePass::runOnOperation() {
 
   buildCXXGlobalInitFunc();
   buildCXXGlobalTlsFunc();
-  if (astCtx->getLangOpts().CUDA && !astCtx->getLangOpts().CUDAIsDevice)
+  if (lowerModule->getLangOpts().CUDA && !lowerModule->getLangOpts().CUDAIsDevice)
     buildCUDAModuleCtor();
 
   buildGlobalCtorDtorList();
@@ -2918,9 +2922,11 @@ std::unique_ptr<Pass> mlir::createLoweringPreparePass() {
   return std::make_unique<LoweringPreparePass>();
 }
 
-std::unique_ptr<Pass>
-mlir::createLoweringPreparePass(clang::ASTContext *astCtx) {
+std::unique_ptr<Pass> mlir::createLoweringPreparePass(
+    cir::LowerModule *lowerModule,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
   auto pass = std::make_unique<LoweringPreparePass>();
-  pass->setASTContext(astCtx);
-  return std::move(pass);
+  pass->setLowerModule(lowerModule);
+  pass->setVFS(std::move(vfs));
+  return pass;
 }

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -527,9 +527,12 @@ cir::GlobalOp LoweringPreparePass::getOrCreateRuntimeVariable(
   return g;
 }
 
-cir::FuncOp LoweringPreparePass::buildRuntimeFunction(
-    mlir::OpBuilder &builder, llvm::StringRef name, mlir::Location loc,
-    cir::FuncType type, cir::GlobalLinkageKind linkage) {
+static cir::FuncOp getOrCreateRuntimeFunction(mlir::OpBuilder &builder,
+                                              mlir::ModuleOp mlirModule,
+                                              llvm::StringRef name,
+                                              mlir::Location loc,
+                                              cir::FuncType type,
+                                              cir::GlobalLinkageKind linkage) {
   cir::FuncOp f = dyn_cast_or_null<FuncOp>(SymbolTable::lookupNearestSymbolFrom(
       mlirModule, StringAttr::get(mlirModule->getContext(), name)));
   if (!f) {
@@ -542,6 +545,13 @@ cir::FuncOp LoweringPreparePass::buildRuntimeFunction(
     assert(!cir::MissingFeatures::opFuncExtraAttrs());
   }
   return f;
+}
+
+cir::FuncOp LoweringPreparePass::buildRuntimeFunction(
+    mlir::OpBuilder &builder, llvm::StringRef name, mlir::Location loc,
+    cir::FuncType type, cir::GlobalLinkageKind linkage) {
+  return getOrCreateRuntimeFunction(builder, mlirModule, name, loc, type,
+                                    linkage);
 }
 
 static mlir::Value lowerScalarToComplexCast(mlir::MLIRContext &ctx,
@@ -1895,7 +1905,7 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
 /// region is non-empty, the ctor loop is wrapped in a cir.cleanup.scope whose
 /// EH cleanup performs a reverse destruction loop using the partial dtor body.
 static void lowerArrayDtorCtorIntoLoop(cir::CIRBaseBuilderTy &builder,
-                                       const cir::LowerModule *lm,
+                                       const cir::LowerModule *lowerModule,
                                        mlir::Operation *op, mlir::Type eltTy,
                                        mlir::Value addr,
                                        mlir::Value numElements,
@@ -1905,8 +1915,8 @@ static void lowerArrayDtorCtorIntoLoop(cir::CIRBaseBuilderTy &builder,
 
   // TODO: instead of getting the size from the lower module, create alias for
   // PtrDiffTy and unify with CIRGen stuff.
-  const unsigned sizeTypeSize =
-      lm->getTarget().getTypeWidth(lm->getTarget().getSignedSizeType());
+  const unsigned sizeTypeSize = lowerModule->getTarget().getTypeWidth(
+      lowerModule->getTarget().getSignedSizeType());
 
   // Both constructors and destructors use end = begin + numElements.
   // Constructors iterate forward [begin, end).  Destructors iterate backward
@@ -2297,8 +2307,8 @@ void LoweringPreparePass::runOnOp(mlir::Operation *op) {
   }
 }
 
-static llvm::StringRef getCUDAPrefix(const cir::LowerModule *lm) {
-  if (lm->getLangOpts().HIP)
+static llvm::StringRef getCUDAPrefix(const cir::LowerModule *lowerModule) {
+  if (lowerModule->getLangOpts().HIP)
     return "hip";
   return "cuda";
 }
@@ -2315,14 +2325,14 @@ namespace {
 struct CUDAModuleRegistrationBuilder {
   CUDAModuleRegistrationBuilder(
       mlir::ModuleOp mlirModule, mlir::MLIRContext &context,
-      const cir::LowerModule &lm, llvm::VersionTuple sdkVersion,
+      const cir::LowerModule &lowerModule, llvm::VersionTuple sdkVersion,
       llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
       llvm::StringMap<FuncOp> &cudaKernelMap,
       llvm::SmallVectorImpl<
           std::pair<cir::GlobalOp, cir::CUDAVarRegistrationInfoAttr>>
           &cudaDeviceVars,
       llvm::SmallVectorImpl<std::pair<std::string, uint32_t>> &globalCtorList)
-      : mlirModule(mlirModule), context(context), lowerModule(&lm),
+      : mlirModule(mlirModule), context(context), lowerModule(&lowerModule),
         sdkVersion(sdkVersion), vfs(std::move(vfs)),
         cudaKernelMap(cudaKernelMap), cudaDeviceVars(cudaDeviceVars),
         globalCtorList(globalCtorList) {}
@@ -2362,17 +2372,8 @@ private:
 cir::FuncOp CUDAModuleRegistrationBuilder::buildRuntimeFunction(
     mlir::OpBuilder &builder, llvm::StringRef name, mlir::Location loc,
     cir::FuncType type, cir::GlobalLinkageKind linkage) {
-  cir::FuncOp f = dyn_cast_or_null<FuncOp>(SymbolTable::lookupNearestSymbolFrom(
-      mlirModule, StringAttr::get(mlirModule->getContext(), name)));
-  if (!f) {
-    f = cir::FuncOp::create(builder, loc, name, type);
-    f.setLinkageAttr(
-        cir::GlobalLinkageKindAttr::get(builder.getContext(), linkage));
-    mlir::SymbolTable::setSymbolVisibility(
-        f, mlir::SymbolTable::Visibility::Private);
-    assert(!cir::MissingFeatures::opFuncExtraAttrs());
-  }
-  return f;
+  return getOrCreateRuntimeFunction(builder, mlirModule, name, loc, type,
+                                    linkage);
 }
 
 /// Creates a global constructor function for the module:

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -1855,9 +1855,15 @@ void LoweringPreparePass::buildCXXGlobalInitFunc() {
   // and makes sure these symbols appear lexicographically behind the symbols
   // with priority (TBD).  Module implementation units behave the same
   // way as a non-modular TU with imports.
-  // TODO: check CXX20ModuleInits
-  if (astCtx->getCurrentNamedModule() &&
-      !astCtx->getCurrentNamedModule()->isModuleImplementation()) {
+  // The C++20 named-module init function name is precomputed by CIRGen and
+  // stored as a module-level attribute, so this pass does not need a live
+  // ASTContext in split-compilation flows. Fall back to the AST-based path
+  // only when the attribute is absent (e.g. tests that bypass CIRGen).
+  if (auto fnNameAttr = mlirModule->getAttrOfType<mlir::StringAttr>(
+          cir::CIRDialect::getCXXModuleInitFnNameAttrName())) {
+    fnName += fnNameAttr.getValue();
+  } else if (astCtx && astCtx->getCurrentNamedModule() &&
+             !astCtx->getCurrentNamedModule()->isModuleImplementation()) {
     llvm::raw_svector_ostream out(fnName);
     std::unique_ptr<clang::MangleContext> mangleCtx(
         astCtx->createMangleContext());

--- a/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/LoweringPrepare.cpp
@@ -41,6 +41,7 @@ using namespace mlir;
 using namespace cir;
 
 namespace mlir {
+#define GEN_PASS_DEF_CUDAREGISTERMODULE
 #define GEN_PASS_DEF_LOWERINGPREPARE
 #include "clang/CIR/Dialect/Passes.h.inc"
 } // namespace mlir
@@ -166,15 +167,8 @@ struct LoweringPreparePass
       cudaDeviceVars;
 
   /// Build the CUDA module constructor that registers the fat binary
-  /// with the CUDA runtime.
+  /// with the CUDA runtime. Delegates to CUDAModuleRegistrationBuilder.
   void buildCUDAModuleCtor();
-  std::optional<FuncOp> buildCUDAModuleDtor();
-  std::optional<FuncOp> buildHIPModuleDtor();
-  std::optional<FuncOp> buildCUDARegisterGlobals();
-  void buildCUDARegisterVars(cir::CIRBaseBuilderTy &builder,
-                             FuncOp regGlobalFunc);
-  void buildCUDARegisterGlobalFunctions(cir::CIRBaseBuilderTy &builder,
-                                        FuncOp regGlobalFunc);
 
   /// Handle static local variable initialization with guard variables.
   void handleStaticLocal(cir::GlobalOp globalOp, cir::LocalInitOp localInitOp);
@@ -2314,6 +2308,73 @@ static std::string addUnderscoredPrefix(llvm::StringRef prefix,
   return ("__" + prefix + name).str();
 }
 
+namespace {
+// Emits the CUDA/HIP module ctor/dtor, fatbin globals and registration calls.
+// All target/LangOpts facts come from the LowerModule, so this runs equally on
+// the in-process CIRGen path and on a serialized .cir resumed by a later cc1.
+struct CUDAModuleRegistrationBuilder {
+  CUDAModuleRegistrationBuilder(
+      mlir::ModuleOp mlirModule, mlir::MLIRContext &context,
+      const cir::LowerModule &lm, llvm::VersionTuple sdkVersion,
+      llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+      llvm::StringMap<FuncOp> &cudaKernelMap,
+      llvm::SmallVectorImpl<
+          std::pair<cir::GlobalOp, cir::CUDAVarRegistrationInfoAttr>>
+          &cudaDeviceVars,
+      llvm::SmallVectorImpl<std::pair<std::string, uint32_t>> &globalCtorList)
+      : mlirModule(mlirModule), context(context), lowerModule(&lm),
+        sdkVersion(sdkVersion), vfs(std::move(vfs)),
+        cudaKernelMap(cudaKernelMap), cudaDeviceVars(cudaDeviceVars),
+        globalCtorList(globalCtorList) {}
+
+  void buildCUDAModuleCtor();
+  std::optional<FuncOp> buildCUDAModuleDtor();
+  std::optional<FuncOp> buildHIPModuleDtor();
+  std::optional<FuncOp> buildCUDARegisterGlobals();
+  void buildCUDARegisterVars(cir::CIRBaseBuilderTy &builder,
+                             FuncOp regGlobalFunc);
+  void buildCUDARegisterGlobalFunctions(cir::CIRBaseBuilderTy &builder,
+                                        FuncOp regGlobalFunc);
+
+private:
+  mlir::MLIRContext &getContext() { return context; }
+
+  cir::FuncOp buildRuntimeFunction(
+      mlir::OpBuilder &builder, llvm::StringRef name, mlir::Location loc,
+      cir::FuncType type,
+      cir::GlobalLinkageKind linkage = cir::GlobalLinkageKind::ExternalLinkage);
+
+  mlir::ModuleOp mlirModule;
+  mlir::MLIRContext &context;
+  const cir::LowerModule *lowerModule;
+  // SDK version is read from TargetOptions, which the module-only LowerModule
+  // (cir-opt) lacks; the caller supplies it explicitly (empty when absent).
+  llvm::VersionTuple sdkVersion;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs;
+  llvm::StringMap<FuncOp> &cudaKernelMap;
+  llvm::SmallVectorImpl<
+      std::pair<cir::GlobalOp, cir::CUDAVarRegistrationInfoAttr>>
+      &cudaDeviceVars;
+  llvm::SmallVectorImpl<std::pair<std::string, uint32_t>> &globalCtorList;
+};
+} // namespace
+
+cir::FuncOp CUDAModuleRegistrationBuilder::buildRuntimeFunction(
+    mlir::OpBuilder &builder, llvm::StringRef name, mlir::Location loc,
+    cir::FuncType type, cir::GlobalLinkageKind linkage) {
+  cir::FuncOp f = dyn_cast_or_null<FuncOp>(SymbolTable::lookupNearestSymbolFrom(
+      mlirModule, StringAttr::get(mlirModule->getContext(), name)));
+  if (!f) {
+    f = cir::FuncOp::create(builder, loc, name, type);
+    f.setLinkageAttr(
+        cir::GlobalLinkageKindAttr::get(builder.getContext(), linkage));
+    mlir::SymbolTable::setSymbolVisibility(
+        f, mlir::SymbolTable::Visibility::Private);
+    assert(!cir::MissingFeatures::opFuncExtraAttrs());
+  }
+  return f;
+}
+
 /// Creates a global constructor function for the module:
 ///
 /// For CUDA:
@@ -2333,7 +2394,7 @@ static std::string addUnderscoredPrefix(llvm::StringRef prefix,
 ///     }
 /// }
 /// \endcode
-void LoweringPreparePass::buildCUDAModuleCtor() {
+void CUDAModuleRegistrationBuilder::buildCUDAModuleCtor() {
   bool isHIP = lowerModule->getLangOpts().HIP;
 
   if (lowerModule->getLangOpts().GPURelocatableDeviceCode)
@@ -2547,7 +2608,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
     //      void __cudaRegisterFatBinaryEnd(void **fatbinHandle);
     // This is CUDA-specific, so no need to use `addUnderscoredPrefix`.
     if (clang::CudaFeatureEnabled(
-            lowerModule->getTarget().getSDKVersion(),
+            sdkVersion,
             clang::CudaFeature::CUDA_USES_FATBIN_REGISTER_END)) {
       cir::CIRBaseBuilderTy globalBuilder(getContext());
       globalBuilder.setInsertionPointToStart(mlirModule.getBody());
@@ -2578,7 +2639,7 @@ void LoweringPreparePass::buildCUDAModuleCtor() {
   cir::ReturnOp::create(builder, loc);
 }
 
-std::optional<FuncOp> LoweringPreparePass::buildCUDAModuleDtor() {
+std::optional<FuncOp> CUDAModuleRegistrationBuilder::buildCUDAModuleDtor() {
   if (!mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName()))
     return {};
 
@@ -2635,7 +2696,7 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDAModuleDtor() {
 /// Despite the name, OG doesn't treat this as a real destructor: putting it on
 /// the dtor list would cause a double-free. It is meant to be registered via
 /// atexit() at the end of the module ctor.
-std::optional<FuncOp> LoweringPreparePass::buildHIPModuleDtor() {
+std::optional<FuncOp> CUDAModuleRegistrationBuilder::buildHIPModuleDtor() {
   if (!mlirModule->getAttr(CIRDialect::getCUDABinaryHandleAttrName()))
     return {};
 
@@ -2694,7 +2755,7 @@ std::optional<FuncOp> LoweringPreparePass::buildHIPModuleDtor() {
   return dtor;
 }
 
-std::optional<FuncOp> LoweringPreparePass::buildCUDARegisterGlobals() {
+std::optional<FuncOp> CUDAModuleRegistrationBuilder::buildCUDARegisterGlobals() {
   if (cudaKernelMap.empty() && cudaDeviceVars.empty())
     return {};
 
@@ -2725,7 +2786,7 @@ std::optional<FuncOp> LoweringPreparePass::buildCUDARegisterGlobals() {
   return regGlobalFunc;
 }
 
-void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
+void CUDAModuleRegistrationBuilder::buildCUDARegisterGlobalFunctions(
     cir::CIRBaseBuilderTy &builder, FuncOp regGlobalFunc) {
   mlir::Location loc = mlirModule.getLoc();
   llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
@@ -2812,7 +2873,7 @@ void LoweringPreparePass::buildCUDARegisterGlobalFunctions(
 // Emit `__{cuda|hip}RegisterVar` calls inside `__{cuda|hip}_register_globals`
 // for every device-side shadow that carries a `cu.var_registration` attribute
 // (attached by `CIRGenNVCUDARuntime::handleVarRegistration`).
-void LoweringPreparePass::buildCUDARegisterVars(cir::CIRBaseBuilderTy &builder,
+void CUDAModuleRegistrationBuilder::buildCUDARegisterVars(cir::CIRBaseBuilderTy &builder,
                                                 FuncOp regGlobalFunc) {
   mlir::Location loc = mlirModule.getLoc();
   llvm::StringRef cudaPrefix = getCUDAPrefix(lowerModule);
@@ -2891,6 +2952,118 @@ void LoweringPreparePass::buildCUDARegisterVars(cir::CIRBaseBuilderTy &builder,
   }
 }
 
+void LoweringPreparePass::buildCUDAModuleCtor() {
+  CUDAModuleRegistrationBuilder builder(
+      mlirModule, getContext(), *lowerModule,
+      lowerModule->getTarget().getSDKVersion(), vfs, cudaKernelMap,
+      cudaDeviceVars, globalCtorList);
+  builder.buildCUDAModuleCtor();
+}
+
+// Walk the module collecting the kernel stubs (carrying `cu.kernel_name`) and
+// device-side shadow globals (carrying `cu.var_registration`) that the
+// registration ctor needs. Used by the standalone pass, where these are not
+// already gathered by LoweringPrepare's main walk.
+static void collectCUDARegistrationOps(
+    mlir::ModuleOp module, llvm::StringMap<FuncOp> &cudaKernelMap,
+    llvm::SmallVectorImpl<
+        std::pair<cir::GlobalOp, cir::CUDAVarRegistrationInfoAttr>>
+        &cudaDeviceVars) {
+  module.walk([&](mlir::Operation *op) {
+    if (auto glob = mlir::dyn_cast<cir::GlobalOp>(op)) {
+      if (auto regAttr = glob->getAttrOfType<CUDAVarRegistrationInfoAttr>(
+              CUDAVarRegistrationInfoAttr::getMnemonic()))
+        cudaDeviceVars.emplace_back(glob, regAttr);
+      return;
+    }
+
+    if (auto fnOp = dyn_cast<cir::FuncOp>(op)) {
+      if (mlir::Attribute attr =
+              fnOp->getAttr(cir::CUDAKernelNameAttr::getMnemonic())) {
+        auto kernelNameAttr = dyn_cast<CUDAKernelNameAttr>(attr);
+        cudaKernelMap[kernelNameAttr.getKernelName()] = fnOp;
+      }
+    }
+  });
+}
+
+static void appendGlobalCtorList(
+    mlir::ModuleOp module, mlir::MLIRContext &context,
+    llvm::ArrayRef<std::pair<std::string, uint32_t>> globalCtorList) {
+  if (globalCtorList.empty())
+    return;
+
+  llvm::SmallVector<mlir::Attribute> attrs;
+  if (auto existing = module->getAttrOfType<mlir::ArrayAttr>(
+          cir::CIRDialect::getGlobalCtorsAttrName())) {
+    for (mlir::Attribute attr : existing.getValue())
+      attrs.push_back(attr);
+  }
+
+  for (mlir::Attribute attr :
+       prepareCtorDtorAttrList<cir::GlobalCtorAttr>(&context, globalCtorList))
+    attrs.push_back(attr);
+  module->setAttr(cir::CIRDialect::getGlobalCtorsAttrName(),
+                  mlir::ArrayAttr::get(&context, attrs));
+}
+
+namespace {
+// Standalone scheduling vehicle for CUDA registration on the .cir resume path,
+// where LoweringPrepare has already run (pre-serialization) and the fatbin only
+// becomes available at the second cc1 invocation. The LowerModule is handed in
+// from the surrounding invocation; cir-opt builds one from the module's triple.
+struct CUDARegisterModulePass
+    : public impl::CUDARegisterModuleBase<CUDARegisterModulePass> {
+  CUDARegisterModulePass() = default;
+
+  CUDARegisterModulePass(const CUDARegisterModulePass &other)
+      : impl::CUDARegisterModuleBase<CUDARegisterModulePass>(other),
+        lowerModule(other.lowerModule), vfs(other.vfs) {}
+
+  CUDARegisterModulePass(cir::LowerModule *lowerModule,
+                         llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs)
+      : lowerModule(lowerModule), vfs(std::move(vfs)) {}
+
+  void runOnOperation() override {
+    mlir::ModuleOp module = getOperation();
+
+    std::unique_ptr<cir::LowerModule> ownedLowerModule;
+    cir::LowerModule *lm = lowerModule;
+    if (!lm) {
+      ownedLowerModule = cir::createLowerModule(module);
+      if (!ownedLowerModule) {
+        module.emitError("CUDA registration requires a module triple");
+        signalPassFailure();
+        return;
+      }
+      lm = ownedLowerModule.get();
+    }
+
+    // SDK version comes from TargetOptions, present only on the invocation-built
+    // LowerModule (resume path). The module-only fallback (cir-opt) has none.
+    llvm::VersionTuple sdkVersion;
+    if (lowerModule)
+      sdkVersion = lowerModule->getTarget().getSDKVersion();
+
+    llvm::StringMap<FuncOp> cudaKernelMap;
+    llvm::SmallVector<std::pair<cir::GlobalOp, cir::CUDAVarRegistrationInfoAttr>>
+        cudaDeviceVars;
+    collectCUDARegistrationOps(module, cudaKernelMap, cudaDeviceVars);
+
+    llvm::SmallVector<std::pair<std::string, uint32_t>, 4> globalCtorList;
+    CUDAModuleRegistrationBuilder builder(module, getContext(), *lm, sdkVersion,
+                                          vfs, cudaKernelMap, cudaDeviceVars,
+                                          globalCtorList);
+    builder.buildCUDAModuleCtor();
+    appendGlobalCtorList(module, getContext(), globalCtorList);
+  }
+
+private:
+  cir::LowerModule *lowerModule = nullptr;
+  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs;
+};
+} // namespace
+
 void LoweringPreparePass::runOnOperation() {
   mlir::Operation *op = getOperation();
   if (isa<::mlir::ModuleOp>(op))
@@ -2920,6 +3093,16 @@ void LoweringPreparePass::runOnOperation() {
 
 std::unique_ptr<Pass> mlir::createLoweringPreparePass() {
   return std::make_unique<LoweringPreparePass>();
+}
+
+std::unique_ptr<Pass> mlir::createCUDARegisterModulePass() {
+  return std::make_unique<CUDARegisterModulePass>();
+}
+
+std::unique_ptr<Pass> mlir::createCUDARegisterModulePass(
+    cir::LowerModule *lowerModule,
+    llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs) {
+  return std::make_unique<CUDARegisterModulePass>(lowerModule, std::move(vfs));
 }
 
 std::unique_ptr<Pass> mlir::createLoweringPreparePass(

--- a/clang/lib/CIR/Dialect/Transforms/MaterializeASTFacts.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/MaterializeASTFacts.cpp
@@ -1,0 +1,80 @@
+//====- MaterializeASTFacts.cpp - Snapshot AST facts into CIR attrs ------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "PassDetail.h"
+#include "clang/AST/Decl.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Interfaces/ASTAttrInterfaces.h"
+#include "llvm/Support/TimeProfiler.h"
+
+using namespace mlir;
+using namespace cir;
+
+namespace mlir {
+#define GEN_PASS_DEF_MATERIALIZEASTFACTS
+#include "clang/CIR/Dialect/Passes.h.inc"
+} // namespace mlir
+
+namespace {
+
+struct MaterializeASTFactsPass
+    : public impl::MaterializeASTFactsBase<MaterializeASTFactsPass> {
+  MaterializeASTFactsPass() = default;
+  void runOnOperation() override;
+};
+
+// Rebuild the `$ast` attribute of a cir.global as a StaticLocalInfoAttr when
+// the current attribute is an AST-backed ASTVarDeclAttr that still holds a
+// live VarDecl pointer. StaticLocalInfoAttr instances are left alone.
+//
+// For now the pass only materializes static-local guarded globals, the
+// subset whose facts LoweringPrepare actually queries through the
+// ASTVarDeclInterface. Other AST-backed attributes that only exist as IR
+// metadata are left untouched so textual IR stays stable.
+static void materializeGlobal(cir::GlobalOp globalOp) {
+  if (!globalOp.getStaticLocalGuard().has_value())
+    return;
+
+  std::optional<cir::ASTVarDeclInterface> iface = globalOp.getAst();
+  if (!iface)
+    return;
+
+  // Already materialized.
+  if (mlir::isa<cir::StaticLocalInfoAttr>(*iface))
+    return;
+
+  auto astBacked = mlir::dyn_cast<cir::ASTVarDeclAttr>(*iface);
+  if (!astBacked)
+    return;
+
+  const clang::VarDecl *vd = astBacked.getAst();
+  if (!vd)
+    return;
+
+  mlir::MLIRContext *ctx = globalOp.getContext();
+  auto snapshot = cir::StaticLocalInfoAttr::get(
+      ctx,
+      /*is_local_var_decl=*/vd->isLocalVarDecl(),
+      /*tls=*/static_cast<uint32_t>(vd->getTLSKind()),
+      /*is_inline=*/vd->isInline(),
+      /*tsk=*/static_cast<uint32_t>(vd->getTemplateSpecializationKind()));
+  globalOp.setAstAttr(snapshot);
+}
+
+void MaterializeASTFactsPass::runOnOperation() {
+  llvm::TimeTraceScope scope("Materialize AST Facts");
+  getOperation()->walk(&materializeGlobal);
+}
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createMaterializeASTFactsPass() {
+  return std::make_unique<MaterializeASTFactsPass>();
+}

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.cpp
@@ -67,7 +67,9 @@ LowerModule::LowerModule(clang::LangOptions langOpts,
                          clang::CodeGenOptions codeGenOpts,
                          mlir::ModuleOp &module,
                          std::unique_ptr<clang::TargetInfo> target)
-    : module(module), target(std::move(target)), abi(createCXXABI(*this)) {}
+    : module(module), langOpts(std::move(langOpts)),
+      codeGenOpts(std::move(codeGenOpts)), target(std::move(target)),
+      abi(createCXXABI(*this)) {}
 
 const TargetLoweringInfo &LowerModule::getTargetLoweringInfo() {
   if (!targetLoweringInfo)
@@ -91,15 +93,11 @@ std::unique_ptr<LowerModule> createLowerModule(mlir::ModuleOp module) {
   targetOptions.Triple = triple.str();
   auto targetInfo = clang::targets::AllocateTarget(triple, targetOptions);
 
-  // FIXME(cir): This just uses the default language options. We need to account
-  // for custom options.
-  // Create context.
-  assert(!cir::MissingFeatures::lowerModuleLangOpts());
+  // The module-only factory has no access to the original cc1 invocation, so
+  // LangOptions and CodeGenOptions remain default-constructed. The
+  // invocation-aware overload below is preferred whenever those options are
+  // available (in-process CIRGen, .cir cc1 input, etc.).
   clang::LangOptions langOpts;
-
-  // FIXME(cir): This just uses the default code generation options. We need to
-  // account for custom options.
-  assert(!cir::MissingFeatures::lowerModuleCodeGenOpts());
   clang::CodeGenOptions codeGenOpts;
 
   if (auto optInfo = mlir::cast_if_present<cir::OptInfoAttr>(
@@ -111,6 +109,14 @@ std::unique_ptr<LowerModule> createLowerModule(mlir::ModuleOp module) {
   return std::make_unique<LowerModule>(std::move(langOpts),
                                        std::move(codeGenOpts), module,
                                        std::move(targetInfo));
+}
+
+std::unique_ptr<LowerModule>
+createLowerModule(mlir::ModuleOp module, const clang::LangOptions &langOpts,
+                  const clang::CodeGenOptions &codeGenOpts,
+                  std::unique_ptr<clang::TargetInfo> target) {
+  return std::make_unique<LowerModule>(langOpts, codeGenOpts, module,
+                                       std::move(target));
 }
 
 } // namespace cir

--- a/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
+++ b/clang/lib/CIR/Dialect/Transforms/TargetLowering/LowerModule.h
@@ -28,6 +28,8 @@ namespace cir {
 
 class LowerModule {
   mlir::ModuleOp module;
+  clang::LangOptions langOpts;
+  clang::CodeGenOptions codeGenOpts;
   const std::unique_ptr<clang::TargetInfo> target;
   std::unique_ptr<TargetLoweringInfo> targetLoweringInfo;
   std::unique_ptr<CIRCXXABI> abi;
@@ -39,18 +41,33 @@ public:
   ~LowerModule() = default;
 
   clang::TargetCXXABI::Kind getCXXABIKind() const {
-    assert(!cir::MissingFeatures::lowerModuleLangOpts());
     return target->getCXXABI().getKind();
   }
 
   CIRCXXABI &getCXXABI() const { return *abi; }
   const clang::TargetInfo &getTarget() const { return *target; }
+  const clang::LangOptions &getLangOpts() const { return langOpts; }
+  const clang::CodeGenOptions &getCodeGenOpts() const { return codeGenOpts; }
   mlir::MLIRContext *getMLIRContext() { return module.getContext(); }
 
   const TargetLoweringInfo &getTargetLoweringInfo();
 };
 
+/// Build a LowerModule from a parsed CIR module alone, deriving the target
+/// from the `cir.triple` attribute. LangOptions and CodeGenOptions are
+/// default-constructed; only the optimization level is recovered from the
+/// `cir.opt_info` attribute when present.
 std::unique_ptr<LowerModule> createLowerModule(mlir::ModuleOp module);
+
+/// Build a LowerModule using the LangOptions, CodeGenOptions, and TargetInfo
+/// from the surrounding compiler invocation. Preferred over the
+/// module-only factory whenever a live invocation is available, since it
+/// captures cc1 flags that influence lowering decisions (HIP/CUDA, OpenMP,
+/// thread-safe statics, target features, etc.).
+std::unique_ptr<LowerModule>
+createLowerModule(mlir::ModuleOp module, const clang::LangOptions &langOpts,
+                  const clang::CodeGenOptions &codeGenOpts,
+                  std::unique_ptr<clang::TargetInfo> target);
 
 } // namespace cir
 

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "clang/CIR/FrontendAction/CIRGenAction.h"
+#include "TargetLowering/LowerModule.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
@@ -18,7 +19,10 @@
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
+#include "clang/CIR/Dialect/Passes.h"
 #include "clang/Basic/DiagnosticFrontend.h"
+#include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/CIRGenerator.h"
 #include "clang/CIR/CIRToCIRPasses.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
@@ -38,6 +42,7 @@
 #include "llvm/Linker/Linker.h"
 #include "llvm/Support/Path.h"
 #include "llvm/Support/SourceMgr.h"
+#include "llvm/Support/VirtualFileSystem.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/IPO/Internalize.h"
 
@@ -155,6 +160,21 @@ static bool linkInModules(CompilerInstance &CI, CodeGenOptions &CGO,
   return false;
 }
 
+// Build a LowerModule from the surrounding cc1 invocation. Used both for
+// in-process CIRGen (where the same TargetInfo also drives the AST) and for
+// the .cir input path, where there is no AST at all.
+static std::unique_ptr<cir::LowerModule>
+makeLowerModuleFromInvocation(CompilerInstance &CI, mlir::ModuleOp module) {
+  // Clone TargetInfo: LowerModule takes ownership and CI keeps its copy.
+  auto target = std::unique_ptr<clang::TargetInfo>(
+      clang::TargetInfo::CreateTargetInfo(CI.getDiagnostics(),
+                                          CI.getInvocation().getTargetOpts()));
+  if (!target)
+    return nullptr;
+  return cir::createLowerModule(module, CI.getLangOpts(), CI.getCodeGenOpts(),
+                                std::move(target));
+}
+
 class CIRGenConsumer : public clang::ASTConsumer {
 
   virtual void anchor();
@@ -228,9 +248,17 @@ public:
 
     if (!FEOptions.ClangIRDisablePasses) {
       // Setup and run CIR pipeline.
-      if (runCIRToCIRPasses(
-              MlirModule, MlirCtx, C, !FEOptions.ClangIRDisableCIRVerifier,
-              FEOptions.ClangIREnableIdiomRecognizer, CGO.OptimizationLevel > 0)
+      std::unique_ptr<cir::LowerModule> lowerModule =
+          makeLowerModuleFromInvocation(CI, MlirModule);
+      if (!lowerModule) {
+        CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
+        return;
+      }
+      if (runCIRToCIRPasses(MlirModule, MlirCtx, C, *lowerModule,
+                            &CI.getVirtualFileSystem(),
+                            !FEOptions.ClangIRDisableCIRVerifier,
+                            FEOptions.ClangIREnableIdiomRecognizer,
+                            CGO.OptimizationLevel > 0)
               .failed()) {
         CI.getDiagnostics().Report(diag::err_cir_to_cir_transform_failed);
         return;

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -25,6 +25,7 @@
 #include "clang/Basic/TargetInfo.h"
 #include "clang/CIR/CIRGenerator.h"
 #include "clang/CIR/CIRToCIRPasses.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
 #include "clang/CIR/LowerToLLVM.h"
@@ -173,6 +174,46 @@ makeLowerModuleFromInvocation(CompilerInstance &CI, mlir::ModuleOp module) {
     return nullptr;
   return cir::createLowerModule(module, CI.getLangOpts(), CI.getCodeGenOpts(),
                                 std::move(target));
+}
+
+// On the .cir resume path the fatbin only exists at this second cc1 invocation
+// (it is produced downstream of the serialized host.cir). Stamp its path so the
+// registration pass can find it. Returns true if a binary was passed.
+static bool stampCUDABinaryHandle(CompilerInstance &CI,
+                                  mlir::ModuleOp mlirModule,
+                                  mlir::MLIRContext &mlirContext) {
+  llvm::StringRef cudaBinaryName = CI.getCodeGenOpts().CudaGpuBinaryFileName;
+  if (cudaBinaryName.empty())
+    return false;
+
+  mlirModule->setAttr(
+      cir::CIRDialect::getCUDABinaryHandleAttrName(),
+      cir::CUDABinaryHandleAttr::get(
+          &mlirContext, mlir::StringAttr::get(&mlirContext, cudaBinaryName)));
+  return true;
+}
+
+// LoweringPrepare already ran (pre-serialization) on this module, so run only
+// the registration step here, sourcing target facts from a LowerModule built
+// off the surrounding invocation.
+static bool runCUDARegisterModulePass(CompilerInstance &CI,
+                                      mlir::ModuleOp mlirModule,
+                                      mlir::MLIRContext &mlirContext) {
+  std::unique_ptr<cir::LowerModule> lowerModule =
+      makeLowerModuleFromInvocation(CI, mlirModule);
+  if (!lowerModule) {
+    reportError(CI, "failed to build LowerModule for CUDA registration");
+    return true;
+  }
+
+  mlir::PassManager pm(&mlirContext);
+  pm.addPass(mlir::createCUDARegisterModulePass(lowerModule.get(),
+                                                &CI.getVirtualFileSystem()));
+  if (mlir::failed(pm.run(mlirModule))) {
+    reportError(CI, "failed to run CUDA registration pass");
+    return true;
+  }
+  return false;
 }
 
 class CIRGenConsumer : public clang::ASTConsumer {
@@ -387,12 +428,18 @@ void CIRGenAction::ExecuteAction() {
   if (!MLIRMod)
     return;
 
+  // Stamp before the emit-cir early return so `-emit-cir` reflects the handle.
+  bool hasCUDABinary = stampCUDABinaryHandle(CI, *MLIRMod, *MLIRCtx);
+
   if (Action == OutputType::EmitCIR) {
     mlir::OpPrintingFlags Flags;
     Flags.enableDebugInfo(/*enable=*/true, /*prettyForm=*/false);
     MLIRMod->print(*OS, Flags);
     return;
   }
+
+  if (hasCUDABinary && runCUDARegisterModulePass(CI, *MLIRMod, *MLIRCtx))
+    return;
 
   std::string mlirSaveTempsOutFile;
   if (!CI.getCodeGenOpts().SaveTempsFilePrefix.empty()) {

--- a/clang/lib/CIR/FrontendAction/CMakeLists.txt
+++ b/clang/lib/CIR/FrontendAction/CMakeLists.txt
@@ -7,6 +7,10 @@ set(LLVM_LINK_COMPONENTS
 
 get_property(dialect_libs GLOBAL PROPERTY MLIR_DIALECT_LIBS)
 
+# CIRGenAction reaches into the Transforms-private LowerModule helper to
+# stand up the AST-free LoweringPrepare pipeline.
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../Dialect/Transforms)
+
 add_clang_library(clangCIRFrontendAction
   CIRGenAction.cpp
 
@@ -24,5 +28,8 @@ add_clang_library(clangCIRFrontendAction
   clangCIRLoweringDirectToLLVM
   clangCodeGen
   MLIRCIR
+  MLIRCIRTargetLowering
+  MLIRCIRTransforms
+  MLIRDLTIDialect
   MLIRIR
   )

--- a/clang/lib/CIR/Lowering/CIRPasses.cpp
+++ b/clang/lib/CIR/Lowering/CIRPasses.cpp
@@ -10,17 +10,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-// #include "clang/AST/ASTContext.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/Pass/PassManager.h"
 #include "clang/CIR/Dialect/Passes.h"
 #include "llvm/Support/TimeProfiler.h"
+#include "llvm/Support/VirtualFileSystem.h"
 
 namespace cir {
 mlir::LogicalResult
 runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
-                  clang::ASTContext &astContext, bool enableVerifier,
-                  bool enableIdiomRecognizer, bool enableCIRSimplify) {
+                  clang::ASTContext &astContext, cir::LowerModule &lowerModule,
+                  llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs,
+                  bool enableVerifier, bool enableIdiomRecognizer,
+                  bool enableCIRSimplify) {
 
   llvm::TimeTraceScope scope("CIR To CIR Passes");
 
@@ -40,7 +42,7 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
 
   pm.addPass(mlir::createTargetLoweringPass());
   pm.addPass(mlir::createCXXABILoweringPass());
-  pm.addPass(mlir::createLoweringPreparePass(&astContext));
+  pm.addPass(mlir::createLoweringPreparePass(&lowerModule, std::move(vfs)));
 
   pm.enableVerifier(enableVerifier);
   (void)mlir::applyPassManagerCLOptions(pm);

--- a/clang/lib/CIR/Lowering/CIRPasses.cpp
+++ b/clang/lib/CIR/Lowering/CIRPasses.cpp
@@ -27,6 +27,11 @@ runCIRToCIRPasses(mlir::ModuleOp theModule, mlir::MLIRContext &mlirContext,
   mlir::PassManager pm(&mlirContext);
   pm.addPass(mlir::createCIRCanonicalizePass());
 
+  // Snapshot AST-derived facts into CIR attributes while the ASTContext is
+  // still live, so later passes (notably LoweringPrepare) can run on
+  // serialized CIR without an AST.
+  pm.addPass(mlir::createMaterializeASTFactsPass());
+
   if (enableCIRSimplify)
     pm.addPass(mlir::createCIRSimplifyPass());
 

--- a/clang/test/CIR/CodeGen/cxx20-module-initializer.cppm
+++ b/clang/test/CIR/CodeGen/cxx20-module-initializer.cppm
@@ -1,0 +1,13 @@
+// RUN: %clang_cc1 -std=c++20 -triple %itanium_abi_triple -emit-cir %s -o %t.cir
+// RUN: FileCheck --input-file=%t.cir %s --check-prefix=CIR
+
+// CIRGen precomputes the mangled C++20 named-module initializer function
+// name and stores it as a module-level attribute so LoweringPrepare can
+// consume it without a live ASTContext after split-compilation.
+
+export module A;
+
+int x = 5;
+
+// CIR: module
+// CIR-SAME: cir.cxx_module_init_fn_name = "_ZGIW1A"

--- a/clang/test/CIR/CodeGen/materialize-ast-facts.cpp
+++ b/clang/test/CIR/CodeGen/materialize-ast-facts.cpp
@@ -1,0 +1,25 @@
+// RUN: %clang_cc1 -std=c++17 -triple x86_64-unknown-linux-gnu -fclangir \
+// RUN:   -emit-cir -mmlir --mlir-print-ir-before=cir-lowering-prepare %s \
+// RUN:   -o %t.cir 2>&1 | FileCheck %s
+
+// The cir-materialize-ast-facts pass runs inside the default CIR pipeline.
+// For static-local variables that carry an ASTVarDecl reference, its effect
+// is that the AST-backed #cir.var.decl placeholder on cir.global is
+// replaced by a concrete #cir.static_local_info attribute with the cached
+// VarDecl facts. The IR dumped immediately before LoweringPrepare must
+// therefore use the cached form and no longer reference #cir.var.decl.
+
+struct HasCtor {
+  HasCtor();
+  int x;
+};
+
+int referenced_inside() {
+  static HasCtor static_local;
+  return static_local.x;
+}
+
+// CHECK-NOT: #cir.var.decl
+// CHECK: cir.global
+// CHECK-SAME: @_ZZ17referenced_insidevE12static_local
+// CHECK-SAME: #cir.static_local_info<{{.*}}is_local_var_decl = true

--- a/clang/test/CIR/CodeGenCUDA/cuda-resume-register.cir
+++ b/clang/test/CIR/CodeGenCUDA/cuda-resume-register.cir
@@ -1,0 +1,40 @@
+// Create a dummy GPU binary file for registration.
+// RUN: echo -n "GPU binary would be here." > %t.fatbin
+
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -x cir -emit-cir \
+// RUN:   -fcuda-include-gpubinary %t.fatbin %s -o - \
+// RUN:   | FileCheck %s --check-prefix=ATTR
+
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -x cir -emit-llvm \
+// RUN:   -fcuda-include-gpubinary %t.fatbin %s -o - \
+// RUN:   | FileCheck %s --check-prefix=LLVM
+
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -x cir -emit-llvm %s -o - \
+// RUN:   | FileCheck %s --check-prefix=NOFATBIN
+
+module {
+  cir.func @_Z21__device_stub__kernelv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z6kernelv">} {
+    cir.return
+  }
+}
+
+// ATTR: cir.cu.binary_handle = #cir.cu.binary_handle<"{{.*}}.fatbin">
+
+// LLVM: @__cuda_fatbin_str = private constant
+// LLVM-SAME: section ".nv_fatbin"
+// LLVM: @__cuda_fatbin_wrapper = {{.*}}constant
+// LLVM-SAME: section ".nvFatBinSegment"
+// LLVM: @__cuda_gpubin_handle = internal global ptr null
+// LLVM: @llvm.global_ctors = appending global
+// LLVM-SAME: @__cuda_module_ctor
+// LLVM: define internal void @__cuda_register_globals
+// LLVM: call{{.*}}@__cudaRegisterFunction
+// LLVM: define internal void @__cuda_module_ctor
+// LLVM: call{{.*}}@__cudaRegisterFatBinary
+// LLVM: call void @__cuda_register_globals
+
+// NOFATBIN-NOT: __cuda_fatbin
+// NOFATBIN-NOT: __cudaRegisterFatBinary
+// NOFATBIN-NOT: __cudaRegisterFunction
+// NOFATBIN-NOT: __cuda_register_globals
+// NOFATBIN-NOT: __cuda_module_ctor

--- a/clang/test/CIR/Transforms/cuda-register-module.cir
+++ b/clang/test/CIR/Transforms/cuda-register-module.cir
@@ -1,0 +1,36 @@
+// Create a dummy GPU binary file for registration.
+// RUN: echo -n "GPU binary would be here." > %t.fatbin
+
+// RUN: sed 's|FATBIN|%t.fatbin|g' %s > %t.with-fatbin.cir
+// RUN: cir-opt %t.with-fatbin.cir -cir-cuda-register-module -o - \
+// RUN:   | FileCheck %s --check-prefix=CUDA
+
+// RUN: sed 's|, cir.cu.binary_handle = #cir.cu.binary_handle<"FATBIN">||g' %s > %t.no-fatbin.cir
+// RUN: cir-opt %t.no-fatbin.cir -cir-cuda-register-module -o - \
+// RUN:   | FileCheck %s --check-prefix=NOFATBIN
+
+module attributes {cir.triple = "x86_64-unknown-linux-gnu", cir.cu.binary_handle = #cir.cu.binary_handle<"FATBIN">} {
+  cir.func @_Z21__device_stub__kernelv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z6kernelv">} {
+    cir.return
+  }
+}
+
+// CUDA: cir.global_ctors = [#cir.global_ctor<"__cuda_module_ctor", 65535>]
+// CUDA: cir.func private @__cudaRegisterFunction
+// CUDA: cir.func internal private @__cuda_register_globals
+// CUDA: cir.call @__cudaRegisterFunction
+// CUDA: cir.global "private" constant cir_private @__cuda_fatbin_str
+// CUDA-SAME: section = ".nv_fatbin"
+// CUDA: cir.global constant cir_private @__cuda_fatbin_wrapper
+// CUDA-SAME: section = ".nvFatBinSegment"
+// CUDA: cir.global "private" internal @__cuda_gpubin_handle
+// CUDA: cir.func private @__cudaRegisterFatBinary
+// CUDA: cir.func internal private @__cuda_module_ctor
+// CUDA: cir.call @__cudaRegisterFatBinary
+// CUDA: cir.call @__cuda_register_globals
+
+// NOFATBIN-NOT: __cuda_fatbin
+// NOFATBIN-NOT: __cudaRegisterFatBinary
+// NOFATBIN-NOT: __cudaRegisterFunction
+// NOFATBIN-NOT: __cuda_register_globals
+// NOFATBIN-NOT: __cuda_module_ctor

--- a/clang/test/CIR/Transforms/materialize-ast-facts-parse.cir
+++ b/clang/test/CIR/Transforms/materialize-ast-facts-parse.cir
@@ -1,0 +1,19 @@
+// RUN: cir-opt %s -o - | FileCheck %s
+
+// Round-trip the StaticLocalInfoAttr through the parser/printer. This proves
+// the attribute has no hidden AST dependency and can be read from textual CIR.
+
+!s32i = !cir.int<s, 32>
+
+module {
+  cir.global "private" internal @counter = #cir.int<0> : !s32i
+    {ast = #cir.static_local_info<is_local_var_decl = true, tls = 0,
+                                  is_inline = false, tsk = 0>}
+}
+
+// CHECK: cir.global
+// CHECK-SAME: #cir.static_local_info<
+// CHECK-SAME: is_local_var_decl = true
+// CHECK-SAME: tls = 0
+// CHECK-SAME: is_inline = false
+// CHECK-SAME: tsk = 0

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -60,6 +60,10 @@ int main(int argc, char **argv) {
   });
 
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createCUDARegisterModulePass();
+  });
+
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return mlir::createGotoSolverPass();
   });
 

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -71,6 +71,14 @@ int main(int argc, char **argv) {
     return mlir::createCallConvLoweringPass();
   });
 
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createMaterializeASTFactsPass();
+  });
+
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createLoweringPreparePass();
+  });
+
   mlir::omp::registerOpenMPPasses();
   mlir::registerTransformsPasses();
 


### PR DESCRIPTION
I opened this to address certain obstacles presented in: https://github.com/RiverDave/llvm-project/pull/7

In the offload-merge pipeline the host TU is lowered to CIR, serialized, and only resumed to an object through a second -x cir cc1 invocation. CUDA registration (module ctor, __cudaRegisterFatBinary, the embedded .nv_fatbin) is built by LoweringPrepare in the first invocation - but the device fatbin doesn't exist yet there, since it's a downstream product of the host.cir we're emitting, so buildCUDAModuleCtor no-ops on the absent CUDABinaryHandleAttr and the object ships without registration. 

The resume invocation is the only place the fatbin actually exists (-fcuda-include-gpubinary), yet it never re-ran registration. This PR factors registration out of LoweringPrepare into a standalone pass parameterized on a small POD (CUDARegisterInfo) instead of an ASTContext, and runs it on the -x cir path: stamp the binary handle, build the ctor, then lower. Architecturally, the Non-merge path is unchanged; HIP rides the same pass via isHIP.