### PR TITLE
[CIR][CUDA] multi-arch support for the CIR offload-merge pipeline

### DIFF
--- a/clang/include/clang/Driver/Action.h
+++ b/clang/include/clang/Driver/Action.h
@@ -363,6 +363,9 @@ private:
   /// The tool chains associated with the list of actions.
   DeviceDependences::ToolChainList DevToolChains;
 
+  /// The bound architectures associated with the list of actions.
+  DeviceDependences::BoundArchList DevBoundArchs;
+
 public:
   OffloadAction(const HostDependence &HDep);
   OffloadAction(const DeviceDependences &DDeps, types::ID Ty);

--- a/clang/lib/Driver/Action.cpp
+++ b/clang/lib/Driver/Action.cpp
@@ -219,7 +219,8 @@ OffloadAction::OffloadAction(const HostDependence &HDep)
 
 OffloadAction::OffloadAction(const DeviceDependences &DDeps, types::ID Ty)
     : Action(OffloadClass, DDeps.getActions(), Ty),
-      DevToolChains(DDeps.getToolChains()) {
+      DevToolChains(DDeps.getToolChains()),
+      DevBoundArchs(DDeps.getBoundArchs()) {
   auto &OKinds = DDeps.getOffloadKinds();
   auto &BArchs = DDeps.getBoundArchs();
   auto &OTCs = DDeps.getToolChains();
@@ -240,7 +241,8 @@ OffloadAction::OffloadAction(const DeviceDependences &DDeps, types::ID Ty)
 OffloadAction::OffloadAction(const HostDependence &HDep,
                              const DeviceDependences &DDeps)
     : Action(OffloadClass, HDep.getAction()), HostTC(HDep.getToolChain()),
-      DevToolChains(DDeps.getToolChains()) {
+      DevToolChains(DDeps.getToolChains()),
+      DevBoundArchs(DDeps.getBoundArchs()) {
   // We use the kinds of the host dependence for this action.
   OffloadingArch = HDep.getBoundArch();
   ActiveOffloadKindMask = HDep.getOffloadKinds();
@@ -282,14 +284,17 @@ void OffloadAction::doOnEachDeviceDependence(
   // more dependence than we have device tool chains.
   assert(getInputs().size() == DevToolChains.size() + (HostTC ? 1 : 0) &&
          "Sizes of action dependences and toolchains are not consistent!");
+  assert(DevToolChains.size() == DevBoundArchs.size() &&
+         "Sizes of device toolchains and bound archs are not consistent!");
 
   // Skip host action
   if (HostTC)
     ++I;
 
   auto TI = DevToolChains.begin();
-  for (; I != E; ++I, ++TI)
-    Work(*I, *TI, (*I)->getOffloadingArch());
+  auto BI = DevBoundArchs.begin();
+  for (; I != E; ++I, ++TI, ++BI)
+    Work(*I, *TI, *BI);
 }
 
 void OffloadAction::doOnEachDependence(const OffloadActionWorkTy &Work) const {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4676,8 +4676,9 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
           if (Action *Fatbin = buildCudaFatBinary(C, AssembleActions,
                                                   FatbinToolChains,
                                                   FatbinArchs))
-            DDeps.add(*Fatbin,
-                      *C.getSingleOffloadToolChain<Action::OFK_Cuda>(),
+            // All arches share the single CUDA device toolchain; the merged
+            // fatbin is arch-agnostic, so any collected TC serves here.
+            DDeps.add(*Fatbin, *FatbinToolChains.front(),
                       /*BoundArch=*/nullptr, Action::OFK_Cuda);
 
           Action *HostAction = OA->getHostDependence();

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4649,9 +4649,10 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
       if (isCIROffloadMerge(C, Args) &&
           (Phase == phases::Backend || Phase == phases::Assemble))
         if (auto *OA = dyn_cast<OffloadAction>(Current)) {
-          
-
           OffloadAction::DeviceDependences DDeps;
+          SmallVector<Action *, 4> AssembleActions;
+          SmallVector<const ToolChain *, 4> FatbinToolChains;
+          SmallVector<const char *, 4> FatbinArchs;
           OA->doOnEachDeviceDependence(
               [&](Action *DepA, const ToolChain *DepTC,
                   const char *DepBoundArch) {
@@ -4661,17 +4662,23 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
                 DeviceAction->propagateDeviceOffloadInfo(Kind, DepBoundArch,
                                                          DepTC);
 
-                // Wrap the assembled cubin into a CUDA fatbinary.
                 if (Kind == Action::OFK_Cuda &&
                     isa<AssembleJobAction>(DeviceAction)) {
-                  Action *Fatbin = buildCudaFatBinary(C, DeviceAction, DepTC,
-                                                      DepBoundArch);
-                  DDeps.add(*Fatbin, *DepTC, /*BoundArch=*/nullptr, Kind);
+                  AssembleActions.push_back(DeviceAction);
+                  FatbinToolChains.push_back(DepTC);
+                  FatbinArchs.push_back(DepBoundArch);
                   return;
                 }
 
                 DDeps.add(*DeviceAction, *DepTC, DepBoundArch, Kind);
               });
+
+          if (Action *Fatbin = buildCudaFatBinary(C, AssembleActions,
+                                                  FatbinToolChains,
+                                                  FatbinArchs))
+            DDeps.add(*Fatbin,
+                      *C.getSingleOffloadToolChain<Action::OFK_Cuda>(),
+                      /*BoundArch=*/nullptr, Action::OFK_Cuda);
 
           Action *HostAction = OA->getHostDependence();
           HostAction = ConstructPhaseAction(C, Args, Phase, HostAction);

--- a/clang/test/Driver/cir-offload-merge.cu
+++ b/clang/test/Driver/cir-offload-merge.cu
@@ -1,5 +1,5 @@
-// Driver pipeline for a CUDA compilation with ClangIR offload merge enabled
-// (single device arch), compiled all the way to an object.
+// Driver pipeline for a CUDA compilation with ClangIR offload merge enabled,
+// compiled all the way to an object.
 
 // REQUIRES: cir-support
 
@@ -11,8 +11,9 @@
 // Host and device translation units are first lowered to serialized CIR, then
 // combined into one cir.offload.container and split back. Each module resumes
 // the backend from -x cir: the device module is lowered to PTX, assembled by
-// ptxas, and the resulting binary is embedded into the host object. The capture
-// variables track that every file is routed to the right consumer.
+// ptxas, packaged into a CUDA fatbinary, and that fatbinary is embedded into
+// the host object. The capture variables track that every file is routed to the
+// right consumer.
 
 // Host TU -> CIR. The host compile must carry the CUDA aux-triple (i.e. present
 // as a CUDA host compile) so it sees __global__, the runtime API, etc.; the
@@ -33,6 +34,24 @@
 // MERGE: "{{.*}}fatbinary{{(\.exe)?}}"{{.*}} "--create" "[[DEV_FATBIN:[^"]+\.fatbin]]"{{.*}} "--image3=kind=elf,sm=80,file=[[DEV_CUBIN]]"
 // Host module: CIR -> object, embedding the device fatbinary.
 // MERGE: "-cc1"{{.*}} "-emit-obj"{{.*}} "-fcuda-include-gpubinary" "[[DEV_FATBIN]]"{{.*}} "-x" "cir" "[[HOST_SPLIT]]"
+
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \
+// RUN:   --cuda-gpu-arch=sm_60 --cuda-gpu-arch=sm_70 --cuda-gpu-arch=sm_80 \
+// RUN:   --cuda-gpu-arch=sm_90 -nocudainc -nocudalib \
+// RUN:   --clangir-offload-merge -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=MULTI
+
+// MULTI: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-split" "-targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda-unknown-sm_60,cuda-nvptx64-nvidia-cuda-unknown-sm_70,cuda-nvptx64-nvidia-cuda-unknown-sm_80,cuda-nvptx64-nvidia-cuda-unknown-sm_90"{{.*}} "-output=[[MULTI_HOST_SPLIT:[^"]+\.cir]]" "-output=[[MULTI_DEV60_SPLIT:[^"]+\.cir]]" "-output=[[MULTI_DEV70_SPLIT:[^"]+\.cir]]" "-output=[[MULTI_DEV80_SPLIT:[^"]+\.cir]]" "-output=[[MULTI_DEV90_SPLIT:[^"]+\.cir]]"
+// MULTI: "-cc1"{{.*}} "-target-cpu" "sm_60"{{.*}} "-o" "[[MULTI_DEV60_PTX:[^"]+\.s]]"{{.*}} "-x" "cir" "[[MULTI_DEV60_SPLIT]]"
+// MULTI: "{{.*}}ptxas{{(\.exe)?}}"{{.*}} "--gpu-name" "sm_60" "--output-file" "[[MULTI_DEV60_CUBIN:[^"]+\.o]]" "[[MULTI_DEV60_PTX]]"
+// MULTI: "-cc1"{{.*}} "-target-cpu" "sm_70"{{.*}} "-o" "[[MULTI_DEV70_PTX:[^"]+\.s]]"{{.*}} "-x" "cir" "[[MULTI_DEV70_SPLIT]]"
+// MULTI: "{{.*}}ptxas{{(\.exe)?}}"{{.*}} "--gpu-name" "sm_70" "--output-file" "[[MULTI_DEV70_CUBIN:[^"]+\.o]]" "[[MULTI_DEV70_PTX]]"
+// MULTI: "-cc1"{{.*}} "-target-cpu" "sm_80"{{.*}} "-o" "[[MULTI_DEV80_PTX:[^"]+\.s]]"{{.*}} "-x" "cir" "[[MULTI_DEV80_SPLIT]]"
+// MULTI: "{{.*}}ptxas{{(\.exe)?}}"{{.*}} "--gpu-name" "sm_80" "--output-file" "[[MULTI_DEV80_CUBIN:[^"]+\.o]]" "[[MULTI_DEV80_PTX]]"
+// MULTI: "-cc1"{{.*}} "-target-cpu" "sm_90"{{.*}} "-o" "[[MULTI_DEV90_PTX:[^"]+\.s]]"{{.*}} "-x" "cir" "[[MULTI_DEV90_SPLIT]]"
+// MULTI: "{{.*}}ptxas{{(\.exe)?}}"{{.*}} "--gpu-name" "sm_90" "--output-file" "[[MULTI_DEV90_CUBIN:[^"]+\.o]]" "[[MULTI_DEV90_PTX]]"
+// MULTI: "{{.*}}fatbinary{{(\.exe)?}}"{{.*}} "--create" "[[MULTI_FATBIN:[^"]+\.fatbin]]"{{.*}} "--image3=kind=elf,sm=60,file=[[MULTI_DEV60_CUBIN]]" "--image3=kind=elf,sm=70,file=[[MULTI_DEV70_CUBIN]]" "--image3=kind=elf,sm=80,file=[[MULTI_DEV80_CUBIN]]" "--image3=kind=elf,sm=90,file=[[MULTI_DEV90_CUBIN]]"
+// MULTI: "-cc1"{{.*}} "-emit-obj"{{.*}} "-fcuda-include-gpubinary" "[[MULTI_FATBIN]]"{{.*}} "-x" "cir" "[[MULTI_HOST_SPLIT]]"
 
 // Without --clangir-offload-merge the normal pipeline runs: no merge/split.
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -x cuda -fclangir \


### PR DESCRIPTION
Depends on: https://github.com/RiverDave/llvm-project/pull/7

  This adds CUDA multi-arch support to the CIR offload-merge pipeline.

The stock CUDA driver compiles each GPU arch separately, then collapses the per-arch device outputs into one CUDA fatbinary before passing it to the host via `-fcuda-include-gpubinary`. The CIR merge path now mirrors that: after splitting the combined CIR container, each device module resumes backend/assemble for its own arch, and the resulting outputs are packaged into one fatbin for the resumed host compile.

This also makes `OffloadAction` preserve the bound arch per device dependence. The split action is a shared node, so the arch cannot live only on the action itself; each dependence needs to carry the arch it is selecting from the split.
