### PR TITLE
[CIR][HIP] HIP support for the CIR offload-merge pipeline

### DIFF
--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -172,7 +172,14 @@ makeLowerModuleFromInvocation(CompilerInstance &CI, mlir::ModuleOp module) {
                                           CI.getInvocation().getTargetOpts()));
   if (!target)
     return nullptr;
-  return cir::createLowerModule(module, CI.getLangOpts(), CI.getCodeGenOpts(),
+  // On the .cir resume path the input language is CIR, so LangOpts.HIP is unset
+  // even for HIP. Recover the device flavor from the aux-triple (amdgcn for HIP)
+  // so the registration pass emits the HIP runtime calls instead of CUDA's.
+  clang::LangOptions langOpts = CI.getLangOpts();
+  if (!langOpts.HIP && !CI.getFrontendOpts().AuxTriple.empty() &&
+      llvm::Triple(CI.getFrontendOpts().AuxTriple).isAMDGPU())
+    langOpts.HIP = true;
+  return cir::createLowerModule(module, langOpts, CI.getCodeGenOpts(),
                                 std::move(target));
 }
 

--- a/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
+++ b/clang/lib/CIR/FrontendAction/CIRGenAction.cpp
@@ -176,8 +176,14 @@ makeLowerModuleFromInvocation(CompilerInstance &CI, mlir::ModuleOp module) {
   // even for HIP. Recover the device flavor from the aux-triple (amdgcn for HIP)
   // so the registration pass emits the HIP runtime calls instead of CUDA's.
   clang::LangOptions langOpts = CI.getLangOpts();
-  if (!langOpts.HIP && !CI.getFrontendOpts().AuxTriple.empty() &&
-      llvm::Triple(CI.getFrontendOpts().AuxTriple).isAMDGPU())
+  bool auxIsAMDGPU = !CI.getFrontendOpts().AuxTriple.empty() &&
+                     llvm::Triple(CI.getFrontendOpts().AuxTriple).isAMDGPU();
+  bool otherAMDGPUOffload =
+      langOpts.OpenMP || langOpts.SYCLIsDevice || langOpts.SYCLIsHost;
+  assert(!(otherAMDGPUOffload && auxIsAMDGPU) &&
+         "non-HIP AMDGPU offload (OpenMP/SYCL) is not supported on the .cir "
+         "resume path");
+  if (!langOpts.HIP && auxIsAMDGPU)
     langOpts.HIP = true;
   return cir::createLowerModule(module, langOpts, CI.getCodeGenOpts(),
                                 std::move(target));

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -3326,6 +3326,38 @@ static Action *buildCudaFatBinary(Compilation &C,
   return C.MakeAction<LinkJobAction>(DeviceActions, types::TY_CUDA_FATBIN);
 }
 
+// Lower each device CIR to bitcode, package the per-arch images into one
+// offload binary (llvm-offload-binary) and emit the HIP fat binary via
+// clang-linker-wrapper, matching the new offload driver (see the HIPNoRDC path
+// in BuildOffloadingActions).
+static Action *buildHipFatBinary(Compilation &C,
+                                 ArrayRef<Action *> DeviceActions,
+                                 ArrayRef<const ToolChain *> ToolChains,
+                                 ArrayRef<const char *> BoundArchs) {
+  assert(DeviceActions.size() == ToolChains.size() &&
+         DeviceActions.size() == BoundArchs.size());
+  ActionList OffloadActions;
+  for (unsigned I = 0, E = DeviceActions.size(); I != E; ++I) {
+    Action *Bitcode =
+        C.MakeAction<BackendJobAction>(DeviceActions[I], types::TY_LLVM_BC);
+    Bitcode->propagateDeviceOffloadInfo(Action::OFK_HIP, BoundArchs[I],
+                                        ToolChains[I]);
+    // Wrap with the arch + toolchain so the packager records the per-image
+    // triple/arch/kind.
+    OffloadAction::DeviceDependences DDep;
+    DDep.add(*Bitcode, *ToolChains[I], BoundArchs[I], Action::OFK_HIP);
+    OffloadActions.push_back(
+        C.MakeAction<OffloadAction>(DDep, types::TY_LLVM_BC));
+  }
+  if (OffloadActions.empty())
+    return nullptr;
+  Action *Packager =
+      C.MakeAction<OffloadPackagerJobAction>(OffloadActions, types::TY_Image);
+  ActionList WrapperInput{Packager};
+  return C.MakeAction<LinkerWrapperJobAction>(WrapperInput,
+                                              types::TY_HIP_FATBIN);
+}
+
 namespace {
 /// Provides a convenient interface for different programming models to generate
 /// the required device actions.
@@ -4650,13 +4682,30 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
           (Phase == phases::Backend || Phase == phases::Assemble))
         if (auto *OA = dyn_cast<OffloadAction>(Current)) {
           OffloadAction::DeviceDependences DDeps;
-          SmallVector<Action *, 4> AssembleActions;
-          SmallVector<const ToolChain *, 4> FatbinToolChains;
-          SmallVector<const char *, 4> FatbinArchs;
+          // CUDA and HIP are mutually exclusive, so one set of per-arch device
+          // inputs serves whichever fatbin builder applies. The collected
+          // element differs by kind: a cubin AssembleJobAction for CUDA, the
+          // device CIR for HIP.
+          SmallVector<Action *, 4> DeviceActions;
+          SmallVector<const ToolChain *, 4> DeviceToolChains;
+          SmallVector<const char *, 4> DeviceArchs;
+          Action::OffloadKind FatbinKind = Action::OFK_None;
           OA->doOnEachDeviceDependence(
               [&](Action *DepA, const ToolChain *DepTC,
                   const char *DepBoundArch) {
                 Action::OffloadKind Kind = DepA->getOffloadingDeviceKind();
+
+                // HIP packages the device CIR at the backend phase; the
+                // resulting fat binary passes through the assemble phase
+                // untouched (it is not TY_PP_Asm).
+                if (Kind == Action::OFK_HIP && Phase == phases::Backend) {
+                  FatbinKind = Kind;
+                  DeviceActions.push_back(DepA);
+                  DeviceToolChains.push_back(DepTC);
+                  DeviceArchs.push_back(DepBoundArch);
+                  return;
+                }
+
                 Action *DeviceAction =
                     ConstructPhaseAction(C, Args, Phase, DepA, Kind);
                 DeviceAction->propagateDeviceOffloadInfo(Kind, DepBoundArch,
@@ -4664,22 +4713,28 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
 
                 if (Kind == Action::OFK_Cuda &&
                     isa<AssembleJobAction>(DeviceAction)) {
-                  AssembleActions.push_back(DeviceAction);
-                  FatbinToolChains.push_back(DepTC);
-                  FatbinArchs.push_back(DepBoundArch);
+                  FatbinKind = Kind;
+                  DeviceActions.push_back(DeviceAction);
+                  DeviceToolChains.push_back(DepTC);
+                  DeviceArchs.push_back(DepBoundArch);
                   return;
                 }
 
                 DDeps.add(*DeviceAction, *DepTC, DepBoundArch, Kind);
               });
 
-          if (Action *Fatbin = buildCudaFatBinary(C, AssembleActions,
-                                                  FatbinToolChains,
-                                                  FatbinArchs))
-            // All arches share the single CUDA device toolchain; the merged
-            // fatbin is arch-agnostic, so any collected TC serves here.
-            DDeps.add(*Fatbin, *FatbinToolChains.front(),
-                      /*BoundArch=*/nullptr, Action::OFK_Cuda);
+          Action *Fatbin = nullptr;
+          if (FatbinKind == Action::OFK_Cuda)
+            Fatbin = buildCudaFatBinary(C, DeviceActions, DeviceToolChains,
+                                        DeviceArchs);
+          else if (FatbinKind == Action::OFK_HIP)
+            Fatbin = buildHipFatBinary(C, DeviceActions, DeviceToolChains,
+                                       DeviceArchs);
+          // All arches share the single device toolchain of their kind; the
+          // merged fatbin is arch-agnostic, so any collected TC serves here.
+          if (Fatbin)
+            DDeps.add(*Fatbin, *DeviceToolChains.front(),
+                      /*BoundArch=*/nullptr, FatbinKind);
 
           Action *HostAction = OA->getHostDependence();
           HostAction = ConstructPhaseAction(C, Args, Phase, HostAction);
@@ -5117,11 +5172,6 @@ Driver::BuildOffloadingActions(Compilation &C, llvm::opt::DerivedArgList &Args,
   if (isCIROffloadMerge(C, Args) && !Args.hasArg(options::OPT_emit_cir) &&
       isa<CompileJobAction>(HostAction) &&
       HostAction->getType() == types::TY_CIR) {
-    // TODO: HIP needs the device fatbin bundling step before the host embed;
-    // wired up in a follow-up. Until then only CUDA is supported here.
-    assert(!C.isOffloadingHostKind(Action::OFK_HIP) &&
-           "ClangIR offload merge for HIP is NYI");
-
     ActionList MergeInputs;
     MergeInputs.push_back(HostAction);
 

--- a/clang/test/CIR/CodeGenCUDA/hip-resume-register.cir
+++ b/clang/test/CIR/CodeGenCUDA/hip-resume-register.cir
@@ -1,0 +1,45 @@
+// Resume a HIP host .cir module and check that the registration pass emits the
+// HIP runtime calls (not CUDA's). The .cir resume path has no HIP language flag
+// on the cc1 line, so HIP is recovered from the aux-triple (amdgcn).
+
+// Create a dummy GPU binary file for registration.
+// RUN: echo -n "GPU binary would be here." > %t.fatbin
+
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -aux-triple amdgcn-amd-amdhsa \
+// RUN:   -x cir -emit-cir -fcuda-include-gpubinary %t.fatbin %s -o - \
+// RUN:   | FileCheck %s --check-prefix=ATTR
+
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -aux-triple amdgcn-amd-amdhsa \
+// RUN:   -x cir -emit-llvm -fcuda-include-gpubinary %t.fatbin %s -o - \
+// RUN:   | FileCheck %s --check-prefix=LLVM
+
+// RUN: %clang_cc1 -triple x86_64-linux-gnu -aux-triple amdgcn-amd-amdhsa \
+// RUN:   -x cir -emit-llvm %s -o - | FileCheck %s --check-prefix=NOFATBIN
+
+module {
+  cir.global external @_Z6kernelv = #cir.ptr<null> : !cir.ptr<!cir.func<()>>
+  cir.func @_Z21__device_stub__kernelv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z6kernelv">} {
+    cir.return
+  }
+}
+
+// ATTR: cir.cu.binary_handle = #cir.cu.binary_handle<"{{.*}}.fatbin">
+
+// LLVM: @__hip_fatbin_str = private constant
+// LLVM-SAME: section ".hip_fatbin"
+// LLVM: @__hip_fatbin_wrapper = {{.*}}constant
+// LLVM-SAME: section ".hipFatBinSegment"
+// LLVM: @__hip_gpubin_handle
+// LLVM: @llvm.global_ctors = appending global
+// LLVM-SAME: @__hip_module_ctor
+// LLVM: define internal void @__hip_register_globals
+// LLVM: call{{.*}}@__hipRegisterFunction
+// LLVM: define internal void @__hip_module_ctor
+// LLVM: call{{.*}}@__hipRegisterFatBinary
+// LLVM: call void @__hip_register_globals
+
+// NOFATBIN-NOT: __hip_fatbin
+// NOFATBIN-NOT: __hipRegisterFatBinary
+// NOFATBIN-NOT: __hipRegisterFunction
+// NOFATBIN-NOT: __hip_register_globals
+// NOFATBIN-NOT: __hip_module_ctor

--- a/clang/test/Driver/cir-offload-merge.hip
+++ b/clang/test/Driver/cir-offload-merge.hip
@@ -1,0 +1,58 @@
+// Driver pipeline for a HIP compilation with ClangIR offload merge enabled,
+// compiled all the way to an object.
+
+// REQUIRES: cir-support
+
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -x hip -fclangir \
+// RUN:   --offload-arch=gfx90a -nogpuinc -nogpulib \
+// RUN:   --clangir-offload-merge -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=MERGE
+
+// Host and device translation units are first lowered to serialized CIR, then
+// combined into one cir.offload.container and split back. The device module
+// resumes from -x cir as LLVM bitcode, the per-arch images are packaged with
+// llvm-offload-binary, clang-linker-wrapper produces the HIP fat binary, and
+// that fat binary is embedded into the host object. This is the new offload
+// driver's HIP packaging (see the HIPNoRDC path in BuildOffloadingActions).
+
+// Host TU -> CIR. The host compile carries the HIP aux-triple so it sees
+// __global__, the runtime API, etc.
+// MERGE: "-cc1"{{.*}} "-aux-triple" "amdgcn-amd-amdhsa"{{.*}} "-emit-cir"{{.*}} "-o" "[[HOST_CIR:[^"]+\.cir]]"
+// Device TU -> CIR.
+// MERGE: "-cc1"{{.*}} "-emit-cir"{{.*}} "-fcuda-is-device"{{.*}} "-target-cpu" "gfx90a"{{.*}} "-o" "[[DEV_CIR:[^"]+\.cir]]"
+// Both CIR modules are forwarded as inputs to -combine; output is the container.
+// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-combine" "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-unknown-gfx90a" "-output=[[CONTAINER:[^"]+\.cir]]" "-input=[[HOST_CIR]]" "-input=[[DEV_CIR]]"
+// The container is split back into one output per target.
+// MERGE: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-split" "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-unknown-gfx90a" "-input=[[CONTAINER]]" "-output=[[HOST_SPLIT:[^"]+\.cir]]" "-output=[[DEV_SPLIT:[^"]+\.cir]]"
+// Device module: CIR -> LLVM bitcode.
+// MERGE: "-cc1"{{.*}} "-emit-llvm-bc"{{.*}} "-fcuda-is-device"{{.*}} "-target-cpu" "gfx90a"{{.*}} "-o" "[[DEV_BC:[^"]+\.bc]]"{{.*}} "-x" "cir" "[[DEV_SPLIT]]"
+// Bitcode -> packaged offload binary.
+// MERGE: "{{.*}}llvm-offload-binary{{(\.exe)?}}" "-o" "[[DEV_IMG:[^"]+]]"{{.*}} "--image=file=[[DEV_BC]],triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=hip"
+// Packaged image -> HIP fat binary.
+// MERGE: "{{.*}}clang-linker-wrapper{{(\.exe)?}}"{{.*}} "--emit-fatbin-only"{{.*}} "-o" "[[DEV_FATBIN:[^"]+\.hipfb]]"
+// Host module: CIR -> object, embedding the device fat binary.
+// MERGE: "-cc1"{{.*}} "-emit-obj"{{.*}} "-fcuda-include-gpubinary" "[[DEV_FATBIN]]"{{.*}} "-x" "cir" "[[HOST_SPLIT]]"
+
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -x hip -fclangir \
+// RUN:   --offload-arch=gfx90a --offload-arch=gfx942 \
+// RUN:   -nogpuinc -nogpulib --clangir-offload-merge -c %s 2>&1 \
+// RUN: | FileCheck %s --check-prefix=MULTI
+
+// MULTI: "{{.*}}cir-offload-merge{{(\.exe)?}}" "-split" "-targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa-unknown-gfx90a,hip-amdgcn-amd-amdhsa-unknown-gfx942"{{.*}} "-output=[[MULTI_HOST_SPLIT:[^"]+\.cir]]" "-output=[[MULTI_DEV90A_SPLIT:[^"]+\.cir]]" "-output=[[MULTI_DEV942_SPLIT:[^"]+\.cir]]"
+// MULTI: "-cc1"{{.*}} "-emit-llvm-bc"{{.*}} "-target-cpu" "gfx90a"{{.*}} "-o" "[[MULTI_DEV90A_BC:[^"]+\.bc]]"{{.*}} "-x" "cir" "[[MULTI_DEV90A_SPLIT]]"
+// MULTI: "-cc1"{{.*}} "-emit-llvm-bc"{{.*}} "-target-cpu" "gfx942"{{.*}} "-o" "[[MULTI_DEV942_BC:[^"]+\.bc]]"{{.*}} "-x" "cir" "[[MULTI_DEV942_SPLIT]]"
+// One packaged offload binary holds both per-arch images.
+// MULTI: "{{.*}}llvm-offload-binary{{(\.exe)?}}" "-o" "{{[^"]+}}"{{.*}} "--image=file=[[MULTI_DEV90A_BC]],triple=amdgcn-amd-amdhsa,arch=gfx90a,kind=hip" "--image=file=[[MULTI_DEV942_BC]],triple=amdgcn-amd-amdhsa,arch=gfx942,kind=hip"
+// MULTI: "{{.*}}clang-linker-wrapper{{(\.exe)?}}"{{.*}} "--emit-fatbin-only"{{.*}} "-o" "[[MULTI_FATBIN:[^"]+\.hipfb]]"
+// MULTI: "-cc1"{{.*}} "-emit-obj"{{.*}} "-fcuda-include-gpubinary" "[[MULTI_FATBIN]]"{{.*}} "-x" "cir" "[[MULTI_HOST_SPLIT]]"
+
+// Without --clangir-offload-merge the normal pipeline runs: no merge/split.
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -x hip -fclangir \
+// RUN:   --offload-arch=gfx90a -nogpuinc -nogpulib \
+// RUN:   -c %s 2>&1 | FileCheck %s --check-prefix=NO-MERGE
+// NO-MERGE-NOT: "-combine"
+// NO-MERGE-NOT: "-split"
+// NO-MERGE-NOT: "-x" "cir"
+
+__global__ void kernel() {}
+void host() { kernel<<<1, 1>>>(); }


### PR DESCRIPTION
Depends on: https://github.com/RiverDave/llvm-project/pull/9

Brings HIP into the CIR offload-merge pipeline. The construction already round-tripped `hip-*` targets, so this drops the `NYI` gate and packages the device side the way HIP does under the **new offload driver, non-RDC**: device modules resume as `-emit-llvm-bc`, the per-arch images go through `Offload::Packager` (`llvm-offload-binary`) and `Offload::Linker` (`clang-linker-wrapper --emit-fatbin-only`) into a `.hipfb`, embedded into the host via `-fcuda-include-gpubinary`. This mirrors the `HIPNoRDC` branch of `BuildOffloadingActions` (unlike CUDA, AMDGPU defers codegen into the wrapper, so we package bitcode rather than emitting a fatbin directly).

One subtlety: the resume is `-x cir`, so `LangOpts.HIP` is unset and registration would fall to the CUDA default. We recover it from the `-aux-triple` (`amdgcn`) in `makeLowerModuleFromInvocation`; registration is otherwise unchanged.

Bindings for `--offload-arch=gfx90a --offload-arch=gfx942`:

```
"x86_64-unknown-linux-gnu" - "clang", inputs: ["dev.hip"], output: "host.cir"
"amdgcn-amd-amdhsa"        - "clang", inputs: ["dev.hip"], output: "dev-gfx90a.cir"
"amdgcn-amd-amdhsa"        - "clang", inputs: ["dev.hip"], output: "dev-gfx942.cir"
"amdgcn-amd-amdhsa"        - "CIR offload merge", inputs: ["host.cir", "dev-gfx90a.cir", "dev-gfx942.cir"], output: "combined.cir"
"amdgcn-amd-amdhsa"        - "CIR offload merge", inputs: ["combined.cir"], outputs: ["host-split.cir", "dev-gfx90a-split.cir", "dev-gfx942-split.cir"]
"amdgcn-amd-amdhsa"        - "clang", inputs: ["dev-gfx90a-split.cir"], output: "dev-gfx90a.bc"
"amdgcn-amd-amdhsa"        - "clang", inputs: ["dev-gfx942-split.cir"], output: "dev-gfx942.bc"
"amdgcn-amd-amdhsa"        - "Offload::Packager", inputs: ["dev-gfx90a.bc", "dev-gfx942.bc"], output: "device.out"
"amdgcn-amd-amdhsa"        - "Offload::Linker", inputs: ["device.out"], output: "device.hipfb"
"x86_64-unknown-linux-gnu" - "clang", inputs: ["host-split.cir", "device.hipfb"], output: "dev.o"
```
