### PR TITLE
[CIR] Initial KernelBindingTable analysis implementation

### DIFF
--- a/clang/include/clang/CIR/Dialect/IR/CIROps.td
+++ b/clang/include/clang/CIR/Dialect/IR/CIROps.td
@@ -5858,7 +5858,8 @@ def CIR_OffloadKindAttr : CIR_EnumAttr<CIR_OffloadKind, "offload_kind"> {
 //===----------------------------------------------------------------------===//
 
 def CIR_OffloadContainerOp : CIR_Op<"offload.container", [
-    NoRegionArguments, NoTerminator, SingleBlock, SymbolTable]> {
+    IsolatedFromAbove, NoRegionArguments, NoTerminator, SingleBlock,
+    SymbolTable]> {
   let summary = "Container for host and device CIR modules";
   let description = [{
     `cir.offload.container` groups one host CIR module with one or more device

--- a/clang/include/clang/CIR/Dialect/Transforms/OffloadOpt/KernelBindingTable.h
+++ b/clang/include/clang/CIR/Dialect/Transforms/OffloadOpt/KernelBindingTable.h
@@ -1,0 +1,58 @@
+//===- KernelBindingTable.h - Host<->device kernel bindings -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Resolves the host device-stub <-> device kernel correspondence inside a
+// cir.offload.container. The bridge is the `cu.kernel_name` attribute carried
+// by each host stub, whose value is the device kernel's mangled symbol name.
+//
+// Usable as an MLIR analysis: getAnalysis<KernelBindingTable>() on a pass
+// anchored at a cir.offload.container.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_CLANG_CIR_DIALECT_TRANSFORMS_OFFLOADOPT_KERNELBINDINGTABLE_H
+#define LLVM_CLANG_CIR_DIALECT_TRANSFORMS_OFFLOADOPT_KERNELBINDINGTABLE_H
+
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "llvm/ADT/MapVector.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringRef.h"
+
+namespace llvm {
+class raw_ostream;
+} // namespace llvm
+
+namespace cir {
+
+// Binding for one kernel, keyed by its device mangled name. A name may resolve
+// in several device modules (multi-arch); the owning module of each kernel is
+// recoverable via k->getParentOfType<mlir::ModuleOp>().
+struct KernelBinding {
+  cir::FuncOp hostStub;
+  llvm::SmallVector<cir::FuncOp, 2> deviceKernels;
+};
+
+class KernelBindingTable {
+public:
+  explicit KernelBindingTable(mlir::Operation *container);
+
+  const KernelBinding *lookup(llvm::StringRef kernelName) const;
+  bool empty() const { return bindings.empty(); }
+  size_t size() const { return bindings.size(); }
+  auto begin() const { return bindings.begin(); }
+  auto end() const { return bindings.end(); }
+
+  void print(llvm::raw_ostream &os) const;
+
+private:
+  llvm::MapVector<llvm::StringRef, KernelBinding> bindings;
+};
+
+} // namespace cir
+
+#endif // LLVM_CLANG_CIR_DIALECT_TRANSFORMS_OFFLOADOPT_KERNELBINDINGTABLE_H

--- a/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(TargetLowering)
+add_subdirectory(OffloadOpt)
 
 add_clang_library(MLIRCIRTransforms
   CallConvLoweringPass.cpp

--- a/clang/lib/CIR/Dialect/Transforms/OffloadOpt/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/OffloadOpt/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_clang_library(MLIRCIROffloadOpt
+  KernelBindingTable.cpp
+
+  DEPENDS
+  MLIRCIROpsIncGen
+
+  LINK_LIBS PUBLIC
+  MLIRCIR
+  MLIRIR
+  MLIRSupport
+  )

--- a/clang/lib/CIR/Dialect/Transforms/OffloadOpt/KernelBindingTable.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/OffloadOpt/KernelBindingTable.cpp
@@ -1,0 +1,61 @@
+//===- KernelBindingTable.cpp - Host<->device kernel bindings -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "clang/CIR/Dialect/Transforms/OffloadOpt/KernelBindingTable.h"
+#include "mlir/IR/SymbolTable.h"
+#include "clang/CIR/Dialect/IR/CIRAttrs.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "llvm/Support/Casting.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace cir;
+
+KernelBindingTable::KernelBindingTable(mlir::Operation *container) {
+  auto containerOp = mlir::cast<cir::OffloadContainerOp>(container);
+  mlir::ModuleOp hostModule = containerOp.getHostModule();
+
+  hostModule.walk([&](cir::FuncOp hostFn) {
+    auto kernelNameAttr = hostFn->getAttrOfType<cir::CUDAKernelNameAttr>(
+        cir::CUDAKernelNameAttr::getMnemonic());
+    if (kernelNameAttr) {
+      bindings[kernelNameAttr.getKernelName()].hostStub = hostFn;
+    }
+  });
+
+  for (mlir::ModuleOp deviceMod : containerOp.getDeviceModules()) {
+    for (auto &binding : bindings) {
+      if (cir::FuncOp kernel = llvm::dyn_cast_if_present<cir::FuncOp>(
+              deviceMod.lookupSymbol(binding.first))) {
+        binding.second.deviceKernels.push_back(kernel);
+      }
+    }
+  }
+}
+
+const KernelBinding *KernelBindingTable::lookup(llvm::StringRef name) const {
+  auto it = bindings.find(name);
+  return it == bindings.end() ? nullptr : &it->second;
+}
+
+void KernelBindingTable::print(llvm::raw_ostream &os) const {
+  os << "// ---- KernelBindingTable ----\n";
+  for (const auto &b : bindings) {
+    cir::FuncOp stub = b.second.hostStub;
+    os << "// - kernel " << b.first << "\n";
+    os << "//   host-stub @" << stub.getName() << "\n";
+    if (b.second.deviceKernels.empty())
+      os << "//   <no device kernel>\n";
+    for (cir::FuncOp kernel : b.second.deviceKernels) {
+      auto mod = kernel->getParentOfType<mlir::ModuleOp>();
+      os << "//   device @" << mod.getSymName().value_or("<unnamed>") << " : @"
+         << kernel.getName() << "\n";
+    }
+    os << "//\n";
+  }
+  os << "// ----------------------------\n";
+}

--- a/clang/test/CIR/Analysis/kernel-bindings.cir
+++ b/clang/test/CIR/Analysis/kernel-bindings.cir
@@ -1,0 +1,73 @@
+// RUN: cir-opt %s -split-input-file \
+// RUN:   -pass-pipeline="builtin.module(cir.offload.container(test-print-kernel-bindings))" \
+// RUN:   2>&1 | FileCheck %s
+
+// One host stub resolving to one device kernel.
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+      cir.func @_Z20__device_stub__scalePff() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z5scalePff">} {
+        cir.return
+      }
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+      cir.func @_Z5scalePff() {
+        cir.return
+      }
+    }
+  }
+}
+
+// CHECK: KernelBindingTable
+// CHECK-NEXT: kernel _Z5scalePff
+// CHECK-NEXT: host-stub @_Z20__device_stub__scalePff
+// CHECK-NEXT: device @device_0 : @_Z5scalePff
+
+// -----
+
+// Same kernel present in two device modules (multi-arch).
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+      cir.func @_Z20__device_stub__scalePff() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z5scalePff">} {
+        cir.return
+      }
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+      cir.func @_Z5scalePff() {
+        cir.return
+      }
+    }
+    builtin.module @device_1 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+      cir.func @_Z5scalePff() {
+        cir.return
+      }
+    }
+  }
+}
+
+// CHECK: KernelBindingTable
+// CHECK-NEXT: kernel _Z5scalePff
+// CHECK-NEXT: host-stub @_Z20__device_stub__scalePff
+// CHECK-NEXT: device @device_0 : @_Z5scalePff
+// CHECK-NEXT: device @device_1 : @_Z5scalePff
+
+// -----
+
+// Host stub whose kernel is absent from every device module.
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+      cir.func @_Z19__device_stub__deadv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z4deadv">} {
+        cir.return
+      }
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+    }
+  }
+}
+
+// CHECK: KernelBindingTable
+// CHECK-NEXT: kernel _Z4deadv
+// CHECK-NEXT: host-stub @_Z19__device_stub__deadv
+// CHECK-NEXT: <no device kernel>

--- a/clang/tools/cir-opt/CMakeLists.txt
+++ b/clang/tools/cir-opt/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 add_clang_tool(cir-opt
   cir-opt.cpp
+  TestKernelBindings.cpp
 )
 
 clang_target_link_libraries(cir-opt
@@ -25,6 +26,7 @@ clang_target_link_libraries(cir-opt
   clangCIRLoweringDirectToLLVM
   CIRRegisterAllDialects
   MLIRCIR
+  MLIRCIROffloadOpt
   MLIRCIRTransforms
 )
 

--- a/clang/tools/cir-opt/TestKernelBindings.cpp
+++ b/clang/tools/cir-opt/TestKernelBindings.cpp
@@ -1,0 +1,45 @@
+//===- TestKernelBindings.cpp - Print the kernel binding table ------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Test pass that constructs and prints a KernelBindingTable, so the analysis
+// can be exercised through cir-opt + FileCheck (mirrors MLIR's test-print-*
+// analysis passes).
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Pass/Pass.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/Transforms/OffloadOpt/KernelBindingTable.h"
+#include "llvm/Support/raw_ostream.h"
+
+using namespace mlir;
+
+namespace {
+struct PrintKernelBindingsPass
+    : public PassWrapper<PrintKernelBindingsPass,
+                         OperationPass<cir::OffloadContainerOp>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(PrintKernelBindingsPass)
+
+  StringRef getArgument() const final { return "test-print-kernel-bindings"; }
+  StringRef getDescription() const final {
+    return "Print the host<->device kernel bindings of a "
+           "cir.offload.container.";
+  }
+  void runOnOperation() override {
+    getAnalysis<cir::KernelBindingTable>().print(llvm::errs());
+  }
+};
+} // namespace
+
+namespace cir {
+namespace test {
+void registerPrintKernelBindingsPass() {
+  PassRegistration<PrintKernelBindingsPass>();
+}
+} // namespace test
+} // namespace cir

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -28,6 +28,12 @@
 struct CIRToLLVMPipelineOptions
     : public mlir::PassPipelineOptions<CIRToLLVMPipelineOptions> {};
 
+namespace cir {
+namespace test {
+void registerPrintKernelBindingsPass();
+} // namespace test
+} // namespace cir
+
 int main(int argc, char **argv) {
   // TODO: register needed MLIR passes for CIR?
   mlir::DialectRegistry registry;
@@ -82,6 +88,8 @@ int main(int argc, char **argv) {
   ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
     return mlir::createLoweringPreparePass();
   });
+
+  cir::test::registerPrintKernelBindingsPass();
 
   mlir::omp::registerOpenMPPasses();
   mlir::registerTransformsPasses();


### PR DESCRIPTION
Adds KernelBindingTable, the analysis that resolves the host device-stub ↔ device kernel correspondence inside a cir.offload.container. The bridge is the cu.kernel_name each host stub carries — its value is the device kernel's mangled symbol — so the table joins each stub to its device kernel(s) across the nested modules. 

I envision this as the primitive the cross-boundary offload opts (dead-kernel elimination, constant propagation) will build on. An analysis would be a good idea since results can be cached between passes if no mutation occurs on the container, giving us an edge in terms of performance.

Exposed as an MLIR analysis (getAnalysis<KernelBindingTable>()) anchored on the container. A test-print-kernel-bindings pass dumps this for FileCheck:
```
cir.offload.container {
  builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
    cir.func @_Z20__device_stub__scalePff() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z5scalePff">} {
      cir.return
    }
  }
  builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
    cir.func @_Z5scalePff() { cir.return }
  }
}
→
// ---- KernelBindingTable ----
// - kernel _Z5scalePff
//   host-stub @_Z20__device_stub__scalePff
//   device @device_0 : @_Z5scalePff
// ----------------------------
```
A name resolving in several device modules (multi-arch) yields one entry per module; a stub with no device match is reported with no device kernel. Check the tests for more details.