### PR TITLE
[CIR] Introduce Dead Kernel Elimination pass under cir.offload.container

### DIFF
--- a/clang/include/clang/CIR/Dialect/Passes.h
+++ b/clang/include/clang/CIR/Dialect/Passes.h
@@ -47,6 +47,7 @@ std::unique_ptr<Pass> createCUDARegisterModulePass(
     cir::LowerModule *lowerModule,
     llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> vfs = nullptr);
 std::unique_ptr<Pass> createMaterializeASTFactsPass();
+std::unique_ptr<Pass> createOffloadDeadKernelEliminationPass();
 std::unique_ptr<Pass> createGotoSolverPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass();
 std::unique_ptr<Pass> createIdiomRecognizerPass(clang::ASTContext *astCtx);

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -213,6 +213,30 @@ def MaterializeASTFacts : Pass<"cir-materialize-ast-facts", "mlir::ModuleOp"> {
   let dependentDialects = ["cir::CIRDialect"];
 }
 
+def OffloadDeadKernelElimination
+    : Pass<"cir-offload-dead-kernel-elimination", "cir::OffloadContainerOp"> {
+  let summary = "Remove device kernels that can never be launched";
+  let description = [{
+    Runs over a `cir.offload.container` and deletes device kernels that are
+    provably unreachable, using the host<->device correspondence from
+    `KernelBindingTable`.
+
+    A kernel is removed when it is not launchable outside this container:
+
+      - a host stub with internal linkage and no launch left (its device
+        kernels die with it), or
+      - a device kernel with no host stub at all -- a static/anonymous kernel
+        never launched in this TU, since an externally-linked kernel always
+        emits an external stub -- provided device code does not still
+        reference it (dynamic parallelism / address-taken).
+
+    Externally-linked kernels are always preserved: another TU may launch them
+    through their external host stub. Scoped to the non-RDC pipeline.
+  }];
+  let constructor = "mlir::createOffloadDeadKernelEliminationPass()";
+  let dependentDialects = ["cir::CIRDialect"];
+}
+
 def IdiomRecognizer : Pass<"cir-idiom-recognizer", "mlir::ModuleOp"> {
   let summary = "Raise calls to C/C++ libraries to CIR operations";
   let description = [{

--- a/clang/include/clang/CIR/Dialect/Passes.td
+++ b/clang/include/clang/CIR/Dialect/Passes.td
@@ -232,6 +232,10 @@ def OffloadDeadKernelElimination
 
     Externally-linked kernels are always preserved: another TU may launch them
     through their external host stub. Scoped to the non-RDC pipeline.
+
+    Dynamic parallelism follows NVIDIA's terminology: kernel A launches kernel B
+    from device code, so B has no host stub -- yet B is live and must be kept.
+    https://docs.nvidia.com/cuda/cuda-programming-guide/04-special-topics/dynamic-parallelism.html
   }];
   let constructor = "mlir::createOffloadDeadKernelEliminationPass()";
   let dependentDialects = ["cir::CIRDialect"];

--- a/clang/lib/CIR/Dialect/Transforms/OffloadOpt/CMakeLists.txt
+++ b/clang/lib/CIR/Dialect/Transforms/OffloadOpt/CMakeLists.txt
@@ -1,11 +1,14 @@
 add_clang_library(MLIRCIROffloadOpt
   KernelBindingTable.cpp
+  DeadKernelElimination.cpp
 
   DEPENDS
   MLIRCIROpsIncGen
+  MLIRCIRPassIncGen
 
   LINK_LIBS PUBLIC
   MLIRCIR
   MLIRIR
+  MLIRPass
   MLIRSupport
   )

--- a/clang/lib/CIR/Dialect/Transforms/OffloadOpt/DeadKernelElimination.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/OffloadOpt/DeadKernelElimination.cpp
@@ -1,0 +1,95 @@
+//===- DeadKernelElimination.cpp - Remove unlaunchable device kernels -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/IR/SymbolTable.h"
+#include "clang/CIR/Dialect/IR/CIRDialect.h"
+#include "clang/CIR/Dialect/IR/CIROpsEnums.h"
+#include "clang/CIR/Dialect/Passes.h"
+#include "clang/CIR/Dialect/Transforms/OffloadOpt/KernelBindingTable.h"
+#include "llvm/ADT/DenseSet.h"
+#include "llvm/ADT/SmallVector.h"
+
+namespace mlir {
+#define GEN_PASS_DEF_OFFLOADDEADKERNELELIMINATION
+#include "clang/CIR/Dialect/Passes.h.inc"
+} // namespace mlir
+
+using namespace mlir;
+using namespace cir;
+
+namespace {
+
+// A symbol is used outside its own body if any reference to it lives in an op
+// that is not nested within the symbol itself. This matters because a CUDA
+// device stub takes its own address to launch, so it always references itself.
+static bool hasUseOutsideSelf(cir::FuncOp fn, mlir::Operation *scope) {
+  auto uses = mlir::SymbolTable::getSymbolUses(fn, scope);
+  if (!uses)
+    return true; // Uses could not be enumerated: conservatively keep.
+  return llvm::any_of(*uses, [&](const mlir::SymbolTable::SymbolUse &use) {
+    return !fn->isProperAncestor(use.getUser());
+  });
+}
+
+static bool isDeviceKernel(cir::FuncOp fn) {
+  cir::CallingConv cc = fn.getCallingConv();
+  return cc == cir::CallingConv::PTXKernel ||
+         cc == cir::CallingConv::AMDGPUKernel;
+}
+
+struct OffloadDeadKernelEliminationPass
+    : public impl::OffloadDeadKernelEliminationBase<
+          OffloadDeadKernelEliminationPass> {
+  void runOnOperation() override;
+};
+
+void OffloadDeadKernelEliminationPass::runOnOperation() {
+  cir::OffloadContainerOp container = getOperation();
+  cir::KernelBindingTable table(container);
+  mlir::ModuleOp hostModule = container.getHostModule();
+
+  llvm::SmallVector<cir::FuncOp> toErase;
+  llvm::DenseSet<cir::FuncOp> live;
+
+  // Phase 1 (stub-anchored): a host stub with internal linkage and no launch
+  // left is dead. External stubs are kept -- another TU may launch through
+  // them. Device kernels of a surviving stub are marked live so phase 2 keeps
+  // them; those of a dead stub fall through to phase 2's device-side check.
+  for (const auto &binding : table) {
+    cir::FuncOp stub = binding.second.hostStub;
+    bool stubDead = cir::isLocalLinkage(stub.getLinkage()) &&
+                    !hasUseOutsideSelf(stub, hostModule);
+    if (stubDead) {
+      toErase.push_back(stub);
+    } else {
+      for (cir::FuncOp kernel : binding.second.deviceKernels)
+        live.insert(kernel);
+    }
+  }
+
+  // Phase 2 (device-anchored): a kernel with no live host stub is a
+  // static/anonymous kernel never launched in this TU. Delete it unless device
+  // code still references it (dynamic parallelism / address-taken).
+  for (mlir::ModuleOp deviceMod : container.getDeviceModules()) {
+    deviceMod.walk([&](cir::FuncOp fn) {
+      if (!isDeviceKernel(fn) || live.contains(fn))
+        return;
+      if (!hasUseOutsideSelf(fn, deviceMod))
+        toErase.push_back(fn);
+    });
+  }
+
+  for (cir::FuncOp fn : toErase)
+    fn.erase();
+}
+
+} // namespace
+
+std::unique_ptr<Pass> mlir::createOffloadDeadKernelEliminationPass() {
+  return std::make_unique<OffloadDeadKernelEliminationPass>();
+}

--- a/clang/lib/CIR/Dialect/Transforms/OffloadOpt/DeadKernelElimination.cpp
+++ b/clang/lib/CIR/Dialect/Transforms/OffloadOpt/DeadKernelElimination.cpp
@@ -50,7 +50,7 @@ struct OffloadDeadKernelEliminationPass
 
 void OffloadDeadKernelEliminationPass::runOnOperation() {
   cir::OffloadContainerOp container = getOperation();
-  cir::KernelBindingTable table(container);
+  cir::KernelBindingTable &table = getAnalysis<cir::KernelBindingTable>();
   mlir::ModuleOp hostModule = container.getHostModule();
 
   llvm::SmallVector<cir::FuncOp> toErase;
@@ -82,6 +82,12 @@ void OffloadDeadKernelEliminationPass::runOnOperation() {
       if (!hasUseOutsideSelf(fn, deviceMod))
         toErase.push_back(fn);
     });
+  }
+
+  // Cache binding table if nothing was deleted.
+  if (toErase.empty()) {
+    markAllAnalysesPreserved();
+    return;
   }
 
   for (cir::FuncOp fn : toErase)

--- a/clang/test/CIR/Transforms/dead-kernel-elimination.cir
+++ b/clang/test/CIR/Transforms/dead-kernel-elimination.cir
@@ -1,0 +1,96 @@
+// RUN: cir-opt %s -split-input-file \
+// RUN:   -pass-pipeline="builtin.module(cir.offload.container(cir-offload-dead-kernel-elimination))" \
+// RUN:   | FileCheck %s
+
+// External kernel, launched: stub and device kernel preserved.
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+      cir.func @_Z18__device_stub__extv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z3extv">} {
+        cir.call @_Z18__device_stub__extv() : () -> ()
+        cir.return
+      }
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+      cir.func @_Z3extv() cc(ptx_kernel) {
+        cir.return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: cir.offload.container
+// CHECK: cir.func @_Z18__device_stub__extv
+// CHECK: cir.func @_Z3extv() cc(ptx_kernel)
+
+// -----
+
+// External kernel, never launched: stub is external, so kept (may escape to
+// another TU); device kernel kept with it.
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+      cir.func @_Z25__device_stub__ext_unusedv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z10ext_unusedv">} {
+        cir.call @_Z25__device_stub__ext_unusedv() : () -> ()
+        cir.return
+      }
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+      cir.func @_Z10ext_unusedv() cc(ptx_kernel) {
+        cir.return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: cir.offload.container
+// CHECK: cir.func @_Z25__device_stub__ext_unusedv
+// CHECK: cir.func @_Z10ext_unusedv() cc(ptx_kernel)
+
+// -----
+
+// Static kernel, never launched: no host stub emitted, only a device kernel.
+// Deleted device-side.
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+      cir.func comdat @_ZL9st_unusedv() cc(ptx_kernel) {
+        cir.return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: cir.offload.container
+// CHECK-NOT: _ZL9st_unusedv
+
+// -----
+
+// Static kernel with no host stub but referenced from device code of a live
+// (launched) kernel -- dynamic parallelism: kept via its device-side use.
+module {
+  cir.offload.container {
+    builtin.module @host attributes {cir.offload.kind = #cir.offload_kind<host>} {
+      cir.func @_Z21__device_stub__parentv() attributes {cu.kernel_name = #cir.cu.kernel_name<"_Z6parentv">} {
+        cir.call @_Z21__device_stub__parentv() : () -> ()
+        cir.return
+      }
+    }
+    builtin.module @device_0 attributes {cir.offload.kind = #cir.offload_kind<device>} {
+      cir.func comdat @_ZL5childv() cc(ptx_kernel) {
+        cir.return
+      }
+      cir.func @_Z6parentv() cc(ptx_kernel) {
+        %0 = cir.get_global @_ZL5childv : !cir.ptr<!cir.func<()>>
+        cir.return
+      }
+    }
+  }
+}
+
+// CHECK-LABEL: cir.offload.container
+// CHECK: cir.func @_Z21__device_stub__parentv
+// CHECK: cir.func comdat @_ZL5childv() cc(ptx_kernel)
+// CHECK: cir.func @_Z6parentv() cc(ptx_kernel)

--- a/clang/test/CIR/Transforms/dead-kernel-elimination.cu
+++ b/clang/test/CIR/Transforms/dead-kernel-elimination.cu
@@ -1,0 +1,31 @@
+// End-to-end dead kernel elimination: real CIRGen output for host and device
+// TUs, merged into a cir.offload.container, then run through the DKE pass.
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -aux-triple nvptx64-nvidia-cuda \
+// RUN:   -target-sdk-version=9.2 -x cuda -I %S/../../CodeGenCUDA/Inputs \
+// RUN:   -emit-cir %s -o %t-host.cir
+// RUN: %clang_cc1 -triple nvptx64-nvidia-cuda -target-sdk-version=9.2 -fcuda-is-device \
+// RUN:   -x cuda -I %S/../../CodeGenCUDA/Inputs -emit-cir %s -o %t-dev.cir
+// RUN: cir-offload-merge -combine -input=%t-host.cir -input=%t-dev.cir \
+// RUN:   -targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 \
+// RUN:   -output=%t-combined.cir
+// RUN: cir-opt %t-combined.cir \
+// RUN:   -pass-pipeline="builtin.module(cir.offload.container(cir-offload-dead-kernel-elimination))" \
+// RUN:   | FileCheck %s --implicit-check-not="dead_static" --implicit-check-not="dead_anon"
+
+// A launched kernel and an externally-linked kernel (which another TU may launch
+// through its external host stub) survive; the static and anonymous-namespace
+// kernels that are never launched here are removed device-side.
+// CHECK-DAG: cir.func{{.*}} @_Z4livev() cc(ptx_kernel)
+// CHECK-DAG: cir.func{{.*}} @_Z10ext_unusedv() cc(ptx_kernel)
+
+#include "cuda.h"
+
+__global__ void live() {}
+static __global__ void dead_static() {}
+namespace {
+__global__ void dead_anon() {}
+} // namespace
+__global__ void ext_unused() {}
+
+void host() { live<<<1, 1>>>(); }

--- a/clang/test/CIR/Transforms/dead-kernel-elimination.hip
+++ b/clang/test/CIR/Transforms/dead-kernel-elimination.hip
@@ -1,0 +1,32 @@
+// End-to-end dead kernel elimination for HIP: real CIRGen output for host and
+// device TUs, merged into a cir.offload.container, then run through the DKE
+// pass. Mirrors dead-kernel-elimination.cu; device kernels here carry
+// cc(amdgpu_kernel) and the host emits a launch-handle global per kernel.
+
+// RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -aux-triple amdgcn-amd-amdhsa \
+// RUN:   -target-sdk-version=9.2 -x hip -I %S/../../CodeGenCUDA/Inputs \
+// RUN:   -emit-cir %s -o %t-host.cir
+// RUN: %clang_cc1 -triple amdgcn-amd-amdhsa -target-cpu gfx900 -target-sdk-version=9.2 \
+// RUN:   -fcuda-is-device -x hip -I %S/../../CodeGenCUDA/Inputs -emit-cir %s -o %t-dev.cir
+// RUN: cir-offload-merge -combine -input=%t-host.cir -input=%t-dev.cir \
+// RUN:   -targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx900 \
+// RUN:   -output=%t-combined.cir
+// RUN: cir-opt %t-combined.cir \
+// RUN:   -pass-pipeline="builtin.module(cir.offload.container(cir-offload-dead-kernel-elimination))" \
+// RUN:   | FileCheck %s --implicit-check-not="dead_static" --implicit-check-not="dead_anon"
+
+// A launched kernel and an externally-linked kernel survive; the static and
+// anonymous-namespace kernels that are never launched here are removed.
+// CHECK-DAG: cir.func{{.*}} @_Z4livev() cc(amdgpu_kernel)
+// CHECK-DAG: cir.func{{.*}} @_Z10ext_unusedv() cc(amdgpu_kernel)
+
+#include "cuda.h"
+
+__global__ void live() {}
+static __global__ void dead_static() {}
+namespace {
+__global__ void dead_anon() {}
+} // namespace
+__global__ void ext_unused() {}
+
+void host() { live<<<1, 1>>>(); }

--- a/clang/tools/cir-opt/cir-opt.cpp
+++ b/clang/tools/cir-opt/cir-opt.cpp
@@ -89,6 +89,10 @@ int main(int argc, char **argv) {
     return mlir::createLoweringPreparePass();
   });
 
+  ::mlir::registerPass([]() -> std::unique_ptr<::mlir::Pass> {
+    return mlir::createOffloadDeadKernelEliminationPass();
+  });
+
   cir::test::registerPrintKernelBindingsPass();
 
   mlir::omp::registerOpenMPPasses();


### PR DESCRIPTION
Adds cir-offload-dead-kernel-elimination, a pass over cir.offload.container that
removes device kernels which can never be launched. This is mostly
handled by the host↔device correspondence from KernelBindingTable we built
from the last patch.

Based on what I could observe in relation to what is dropped or not:
A kernel is dropped only when it isn't launchable from outside the container:

- an internal-linkage host stub with no remaining launch (its device kernels go
  with it), or
- a device kernel with no host stub at all -- a static/anonymous kernel never
  launched in this TU, since externally-linked kernels always emit an external
  stub another TU can reach.
  
 The rest should be pretty self-explanatory based on comments/docs.