### PR TITLE
[CIR] Run offload-container passes in the offload-merge pipeline

### DIFF
--- a/clang/test/CIR/Transforms/dead-kernel-elimination.cu
+++ b/clang/test/CIR/Transforms/dead-kernel-elimination.cu
@@ -1,5 +1,7 @@
 // End-to-end dead kernel elimination: real CIRGen output for host and device
-// TUs, merged into a cir.offload.container, then run through the DKE pass.
+// TUs, merged into a cir.offload.container. The merge tool runs the
+// offload-container passes (DKE) by default, so the combined container comes
+// out with the dead kernels already removed.
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -aux-triple nvptx64-nvidia-cuda \
 // RUN:   -target-sdk-version=9.2 -x cuda -I %S/../../CodeGenCUDA/Inputs \
@@ -9,9 +11,8 @@
 // RUN: cir-offload-merge -combine -input=%t-host.cir -input=%t-dev.cir \
 // RUN:   -targets=host-x86_64-unknown-linux-gnu,cuda-nvptx64-nvidia-cuda--sm_80 \
 // RUN:   -output=%t-combined.cir
-// RUN: cir-opt %t-combined.cir \
-// RUN:   -pass-pipeline="builtin.module(cir.offload.container(cir-offload-dead-kernel-elimination))" \
-// RUN:   | FileCheck %s --implicit-check-not="dead_static" --implicit-check-not="dead_anon"
+// RUN: FileCheck %s --input-file=%t-combined.cir \
+// RUN:   --implicit-check-not="dead_static" --implicit-check-not="dead_anon"
 
 // A launched kernel and an externally-linked kernel (which another TU may launch
 // through its external host stub) survive; the static and anonymous-namespace

--- a/clang/test/CIR/Transforms/dead-kernel-elimination.hip
+++ b/clang/test/CIR/Transforms/dead-kernel-elimination.hip
@@ -1,7 +1,8 @@
 // End-to-end dead kernel elimination for HIP: real CIRGen output for host and
-// device TUs, merged into a cir.offload.container, then run through the DKE
-// pass. Mirrors dead-kernel-elimination.cu; device kernels here carry
-// cc(amdgpu_kernel) and the host emits a launch-handle global per kernel.
+// device TUs, merged into a cir.offload.container by the merge tool, which runs
+// the offload-container passes (DKE) by default. Mirrors
+// dead-kernel-elimination.cu; device kernels here carry cc(amdgpu_kernel) and
+// the host emits a launch-handle global per kernel.
 
 // RUN: %clang_cc1 -triple x86_64-unknown-linux-gnu -aux-triple amdgcn-amd-amdhsa \
 // RUN:   -target-sdk-version=9.2 -x hip -I %S/../../CodeGenCUDA/Inputs \
@@ -11,9 +12,8 @@
 // RUN: cir-offload-merge -combine -input=%t-host.cir -input=%t-dev.cir \
 // RUN:   -targets=host-x86_64-unknown-linux-gnu,hip-amdgcn-amd-amdhsa--gfx900 \
 // RUN:   -output=%t-combined.cir
-// RUN: cir-opt %t-combined.cir \
-// RUN:   -pass-pipeline="builtin.module(cir.offload.container(cir-offload-dead-kernel-elimination))" \
-// RUN:   | FileCheck %s --implicit-check-not="dead_static" --implicit-check-not="dead_anon"
+// RUN: FileCheck %s --input-file=%t-combined.cir \
+// RUN:   --implicit-check-not="dead_static" --implicit-check-not="dead_anon"
 
 // A launched kernel and an externally-linked kernel survive; the static and
 // anonymous-namespace kernels that are never launched here are removed.

--- a/clang/tools/cir-offload-merge/CMakeLists.txt
+++ b/clang/tools/cir-offload-merge/CMakeLists.txt
@@ -13,6 +13,7 @@ clang_target_link_libraries(cir-offload-merge
   clangDriver
   CIROpenMPSupport
   MLIRCIR
+  MLIRCIROffloadOpt
 )
 
 target_link_libraries(cir-offload-merge
@@ -20,5 +21,6 @@ target_link_libraries(cir-offload-merge
   ${dialect_libs}
   MLIRIR
   MLIRParser
+  MLIRPass
   MLIRSupport
 )

--- a/clang/tools/cir-offload-merge/cir-offload-merge.cpp
+++ b/clang/tools/cir-offload-merge/cir-offload-merge.cpp
@@ -24,11 +24,13 @@
 #include "mlir/IR/OwningOpRef.h"
 #include "mlir/IR/Verifier.h"
 #include "mlir/Parser/Parser.h"
+#include "mlir/Pass/PassManager.h"
 #include "mlir/Support/FileUtilities.h"
 #include "mlir/Support/LogicalResult.h"
 #include "clang/Basic/TargetID.h"
 #include "clang/CIR/Dialect/IR/CIRDialect.h"
 #include "clang/CIR/Dialect/OpenMP/RegisterOpenMPExtensions.h"
+#include "clang/CIR/Dialect/Passes.h"
 #include "clang/Driver/OffloadBundler.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/STLExtras.h"
@@ -310,6 +312,21 @@ combineInputs(llvm::ArrayRef<InputTarget> inputTargets,
   return combinedModule;
 }
 
+// Run the offload-container optimization passes on the freshly combined module.
+// This is the pipeline seam where cross-boundary opts (DKE, and later const
+// prop) run while host and device modules are still joined in one container.
+// They run by default so the driver need only invoke -combine, with no per-pass
+// flags to thread through the offload actions.
+int runOffloadOptPasses(mlir::ModuleOp module) {
+  mlir::PassManager pm(module.getContext(), mlir::ModuleOp::getOperationName());
+  pm.nest<cir::OffloadContainerOp>().addPass(
+      mlir::createOffloadDeadKernelEliminationPass());
+
+  if (mlir::failed(pm.run(module)))
+    return reportError("offload-container passes failed");
+  return 0;
+}
+
 int writeModuleToOutput(mlir::ModuleOp module, llvm::StringRef outputFileName) {
   std::string errorMessage;
   std::unique_ptr<llvm::ToolOutputFile> outputFile =
@@ -426,6 +443,9 @@ int main(int argc, char **argv) {
 
     if (mlir::failed(mlir::verify(*combinedModule)))
       return reportError("failed to verify combined module");
+
+    if (int errorCode = runOffloadOptPasses(*combinedModule))
+      return errorCode;
 
     return writeModuleToOutput(*combinedModule, OutputFileNames.front());
   }

--- a/clang/tools/cir-offload-merge/cir-offload-merge.cpp
+++ b/clang/tools/cir-offload-merge/cir-offload-merge.cpp
@@ -313,10 +313,8 @@ combineInputs(llvm::ArrayRef<InputTarget> inputTargets,
 }
 
 // Run the offload-container optimization passes on the freshly combined module.
-// This is the pipeline seam where cross-boundary opts (DKE, and later const
-// prop) run while host and device modules are still joined in one container.
-// They run by default so the driver need only invoke -combine, with no per-pass
-// flags to thread through the offload actions.
+// This is the pipeline seam where cross-boundary opts (DKE, and other passes)
+// run while host and device modules are still joined in one container.
 int runOffloadOptPasses(mlir::ModuleOp module) {
   mlir::PassManager pm(module.getContext(), mlir::ModuleOp::getOperationName());
   pm.nest<cir::OffloadContainerOp>().addPass(


### PR DESCRIPTION
Wire the offload-container optimization passes (currently dead kernel elimination) into cir-offload-merge -combine: they run on the freshly built container before it is written out. They run by default, so the driver only invokes -combine, with no per-pass flags to thread through the offload actions as discussed.